### PR TITLE
Use RxLoader instead of AsyncTaskLoader.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,6 +111,11 @@ dependencies {
     compile 'ca.rmen:rhymer:1.1.0'
     compile 'ca.rmen:porter-stemmer:1.0.0'
     compile 'org.jraf:prefs:1.0.1'
+    compile 'io.reactivex:rxandroid:1.1.0'
+    compile 'io.reactivex:rxjava:1.1.1'
+    compile ('me.tatarka.rxloader:rxloader:1.1.0') {
+        exclude group: 'io.reactivex', module: 'rxandroid'
+    }
 
     retrolambdaConfig 'net.orfjackal.retrolambda:retrolambda:2.3.0'
 }

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListFactory.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListFactory.java
@@ -23,7 +23,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.content.AsyncTaskLoader;
 import android.util.Log;
 
 import ca.rmen.android.poetassistant.Constants;
@@ -81,16 +80,15 @@ public class ResultListFactory {
         }
     }
 
-    public static AsyncTaskLoader<? extends ResultListData<?>> createLoader(Tab tab, Activity activity, String query, String filter) {
+    public static ResultListLoader<? extends ResultListData> createLoader(Tab tab, Activity activity) {
         switch (tab) {
             case RHYMER:
-                return new RhymerLoader(activity, query, filter);
+                return new RhymerLoader(activity);
             case THESAURUS:
-                return new ThesaurusLoader(activity, query, filter);
+                return new ThesaurusLoader(activity);
             case DICTIONARY:
             default:
-                return new DictionaryLoader(activity, query);
-
+                return new DictionaryLoader(activity);
         }
     }
 

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListFragment.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListFragment.java
@@ -27,8 +27,6 @@ import android.os.Bundle;
 import android.speech.tts.TextToSpeech;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.LoaderManager;
-import android.support.v4.content.Loader;
 import android.support.v7.widget.LinearLayoutManager;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -54,11 +52,14 @@ import ca.rmen.android.poetassistant.Tts;
 import ca.rmen.android.poetassistant.VectorCompat;
 import ca.rmen.android.poetassistant.databinding.FragmentResultListBinding;
 import ca.rmen.android.poetassistant.main.Tab;
+import me.tatarka.rxloader.RxLoader2;
+import me.tatarka.rxloader.RxLoaderManagerCompat;
+import me.tatarka.rxloader.RxLoaderObserver;
+import rx.schedulers.Schedulers;
 
 
 public class ResultListFragment<T> extends Fragment
         implements
-        LoaderManager.LoaderCallbacks<ResultListData<T>>,
         InputDialogFragment.InputDialogListener {
     private static final String TAG = Constants.TAG + ResultListFragment.class.getSimpleName();
     private static final int ACTION_FILTER = 0;
@@ -73,6 +74,8 @@ public class ResultListFragment<T> extends Fragment
     private ResultListAdapter<T> mAdapter;
     private ResultListData<T> mData;
     private Tts mTts;
+    private ResultListLoader<ResultListData<T>> mLoader;
+    private RxLoader2<String, String, ResultListData<T>> mRxLoader;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -115,8 +118,9 @@ public class ResultListFragment<T> extends Fragment
         //noinspection unchecked
         mAdapter = (ResultListAdapter<T>) ResultListFactory.createAdapter(getActivity(), mTab);
         mBinding.recyclerView.setAdapter(mAdapter);
-        getLoaderManager().initLoader(mTab.ordinal(), getArguments(), this);
+        createLoader();
         updatePlayButton();
+        updateUi();
     }
 
     @Override
@@ -154,16 +158,12 @@ public class ResultListFragment<T> extends Fragment
         Log.d(TAG, mTab + ": query() called with: " + "query = [" + query + "]");
         mBinding.tvListHeader.setText(query);
         mBinding.filter.setVisibility(View.GONE);
-        Bundle args = new Bundle(1);
-        args.putString(EXTRA_QUERY, query);
-        getLoaderManager().restartLoader(mTab.ordinal(), args, this);
+        mRxLoader.restart(query, null);
     }
 
     private void filter(String filter) {
-        Bundle args = new Bundle(2);
-        args.putString(EXTRA_QUERY, mBinding.tvListHeader.getText().toString());
-        args.putString(EXTRA_FILTER, filter);
-        getLoaderManager().restartLoader(mTab.ordinal(), args, this);
+        String query = mBinding.tvListHeader.getText().toString();
+        mRxLoader.restart(query, filter);
     }
 
     private void updatePlayButton() {
@@ -172,34 +172,35 @@ public class ResultListFragment<T> extends Fragment
         mBinding.btnPlay.setVisibility(playButtonVisibility);
     }
 
-    @Override
-    public Loader<ResultListData<T>> onCreateLoader(int id, Bundle args) {
-        Log.d(TAG, mTab + ": onCreateLoader() called with: " + "id = [" + id + "], args = [" + args + "]");
-        String query = "";
-        String filter = "";
-        if (args != null) {
-            query = args.getString(EXTRA_QUERY);
-            filter = args.getString(EXTRA_FILTER);
-            mBinding.tvListHeader.setText(query);
-        }
+    private void createLoader() {
         mBinding.recyclerView.scrollToPosition(0); // why do I have to do this?
         //noinspection unchecked
-        return (Loader<ResultListData<T>>) ResultListFactory.createLoader(mTab, getActivity(), query, filter);
+        mLoader = (ResultListLoader<ResultListData<T>>) ResultListFactory.createLoader(mTab, getActivity());
+        mRxLoader = RxLoaderManagerCompat.get(this).create(
+                (query, filter) -> {
+                    return mLoader.observeEntries(query, filter).subscribeOn(Schedulers.io());
+                },
+                onLoadFinished()
+        );
     }
 
-    @Override
-    public void onLoadFinished(Loader<ResultListData<T>> loader, ResultListData<T> data) {
-        Log.d(TAG, mTab + ": onLoadFinished() called with: " + "loader = [" + loader + "], data = [" + data + "]");
-        mAdapter.clear();
-        //noinspection unchecked
-        mAdapter.addAll(data.data);
-        mData = data;
-        updateUi();
+    private RxLoaderObserver<ResultListData<T>> onLoadFinished() {
+        return new RxLoaderObserver<ResultListData<T>>() {
+            @Override
+            public void onNext(ResultListData<T> data) {
 
-        // Hide the keyboard
-        mBinding.recyclerView.requestFocus();
-        InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
-        imm.hideSoftInputFromWindow(mBinding.recyclerView.getWindowToken(), 0);
+                Log.d(TAG, mTab + ": onLoadFinished() called with: " + "data = [" + data + "]");
+                mAdapter.clear();
+                mAdapter.addAll(data.data);
+                mData = data;
+                updateUi();
+
+                // Hide the keyboard
+                mBinding.recyclerView.requestFocus();
+                InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.hideSoftInputFromWindow(mBinding.recyclerView.getWindowToken(), 0);
+            }
+        };
     }
 
     private void updateUi() {
@@ -232,14 +233,6 @@ public class ResultListFragment<T> extends Fragment
             mBinding.recyclerView.setVisibility(View.VISIBLE);
         }
         getActivity().supportInvalidateOptionsMenu();
-    }
-
-    @Override
-    public void onLoaderReset(Loader<ResultListData<T>> loader) {
-        Log.d(TAG, mTab + ": onLoaderReset() called with: " + "loader = [" + loader + "]");
-        mAdapter.clear();
-        mData = null;
-        updateUi();
     }
 
     @Override

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListLoader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016 Carmen Alvarez
+ *
+ * This file is part of Poet Assistant.
+ *
+ * Poet Assistant is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Poet Assistant is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ca.rmen.android.poetassistant.main.dictionaries;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+import java.util.Collections;
+
+import rx.Observable;
+
+public abstract class ResultListLoader<T> {
+
+    private final Context mContext;
+
+    protected ResultListLoader(Context context) {
+        mContext = context.getApplicationContext();
+    }
+
+    public Observable<T> observeEntries(String query, String filter) {
+        if (TextUtils.isEmpty(query)) {
+            //noinspection unchecked
+            return Observable.just((T) Collections.emptyList());
+        } else {
+            return Observable.defer(() -> Observable.just(getEntries(query, filter)));
+        }
+    }
+
+    protected Context getContext() {
+        return mContext;
+    }
+
+    protected abstract T getEntries(String query, String filter);
+
+}

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/dictionary/DictionaryLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/dictionary/DictionaryLoader.java
@@ -20,7 +20,6 @@
 package ca.rmen.android.poetassistant.main.dictionaries.dictionary;
 
 import android.content.Context;
-import android.support.v4.content.AsyncTaskLoader;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -30,43 +29,25 @@ import java.util.List;
 
 import ca.rmen.android.poetassistant.Constants;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListData;
+import ca.rmen.android.poetassistant.main.dictionaries.ResultListLoader;
 
-public class DictionaryLoader extends AsyncTaskLoader<ResultListData<DictionaryEntry.DictionaryEntryDetails>> {
+public class DictionaryLoader extends ResultListLoader<ResultListData<DictionaryEntry.DictionaryEntryDetails>> {
 
     private static final String TAG = Constants.TAG + DictionaryLoader.class.getSimpleName();
 
-    private final String mQuery;
-    private ResultListData<DictionaryEntry.DictionaryEntryDetails> mResult;
-
-    public DictionaryLoader(Context context, String query) {
+    public DictionaryLoader(Context context) {
         super(context);
-        mQuery = query;
     }
 
     @Override
-    public ResultListData<DictionaryEntry.DictionaryEntryDetails> loadInBackground() {
+    protected ResultListData<DictionaryEntry.DictionaryEntryDetails> getEntries(String query, String filter) {
         Log.d(TAG, "loadInBackground() called with: " + "");
         List<DictionaryEntry.DictionaryEntryDetails> result = new ArrayList<>();
-        if(TextUtils.isEmpty(mQuery)) return new ResultListData<>(mQuery, result);
+        if(TextUtils.isEmpty(query)) return new ResultListData<>(query, result);
         Dictionary dictionary = Dictionary.getInstance(getContext());
-        DictionaryEntry entry = dictionary.lookup(mQuery);
+        DictionaryEntry entry = dictionary.lookup(query);
         Collections.addAll(result, entry.details);
         return new ResultListData<>(entry.word, result);
-    }
-
-    @Override
-    public void deliverResult(ResultListData<DictionaryEntry.DictionaryEntryDetails> data) {
-        Log.d(TAG, "deliverResult() called with: query = " + mQuery + ", data = [" + data + "]");
-        mResult = data;
-        if (isStarted()) super.deliverResult(data);
-    }
-
-    @Override
-    protected void onStartLoading() {
-        super.onStartLoading();
-        Log.d(TAG, "onStartLoading() called with: query = " + mQuery);
-        if (mResult != null) super.deliverResult(mResult);
-        else forceLoad();
     }
 
 }

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLoader.java
@@ -20,7 +20,6 @@
 package ca.rmen.android.poetassistant.main.dictionaries.rt;
 
 import android.content.Context;
-import android.support.v4.content.AsyncTaskLoader;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -31,43 +30,38 @@ import java.util.Set;
 import ca.rmen.android.poetassistant.Constants;
 import ca.rmen.android.poetassistant.R;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListData;
+import ca.rmen.android.poetassistant.main.dictionaries.ResultListLoader;
 import ca.rmen.rhymer.RhymeResult;
 
-public class RhymerLoader extends AsyncTaskLoader<ResultListData<RTEntry>> {
+public class RhymerLoader extends ResultListLoader<ResultListData<RTEntry>> {
 
     private static final String TAG = Constants.TAG + RhymerLoader.class.getSimpleName();
 
-    private final String mQuery;
-    private final String mFilter;
-    private ResultListData<RTEntry> mResult;
-
-    public RhymerLoader(Context context, String query, String filter) {
+    public RhymerLoader(Context context) {
         super(context);
-        mQuery = query;
-        mFilter = filter;
     }
 
     @Override
-    public ResultListData<RTEntry> loadInBackground() {
-        Log.d(TAG, "loadInBackground() called with: query = " + mQuery + ", filter = " + mFilter);
+    protected ResultListData<RTEntry> getEntries(String query, String filter) {
+        Log.d(TAG, "getEntries() called with: " + "query = [" + query + "], filter = [" + filter + "]");
 
         List<RTEntry> data = new ArrayList<>();
         Rhymer rhymer = Rhymer.getInstance(getContext());
-        if (TextUtils.isEmpty(mQuery)) return emptyResult();
+        if (TextUtils.isEmpty(query)) return emptyResult(query);
 
-        List<RhymeResult> rhymeResults = rhymer.getRhymingWords(mQuery);
+        List<RhymeResult> rhymeResults = rhymer.getRhymingWords(query);
         if (rhymeResults == null) {
-            return emptyResult();
+            return emptyResult(query);
         }
-        if (!TextUtils.isEmpty(mFilter)) {
-            Set<String> synonyms = Thesaurus.getInstance(getContext()).getFlatSynonyms(mFilter);
-            if (synonyms.isEmpty()) return emptyResult();
+        if (!TextUtils.isEmpty(filter)) {
+            Set<String> synonyms = Thesaurus.getInstance(getContext()).getFlatSynonyms(filter);
+            if (synonyms.isEmpty()) return emptyResult(query);
             rhymeResults = filter(rhymeResults, synonyms);
         }
         for (RhymeResult rhymeResult : rhymeResults) {
             // Add the word variant, if there are multiple pronunciations.
             if (rhymeResults.size() > 1) {
-                String heading = mQuery + " (" + (rhymeResult.variantNumber + 1) + ")";
+                String heading = query + " (" + (rhymeResult.variantNumber + 1) + ")";
                 data.add(new RTEntry(RTEntry.Type.HEADING, heading));
             }
 
@@ -76,26 +70,11 @@ public class RhymerLoader extends AsyncTaskLoader<ResultListData<RTEntry>> {
             addResultSection(data, R.string.rhyme_section_two_syllables, rhymeResult.twoSyllableRhymes);
             addResultSection(data, R.string.rhyme_section_three_syllables, rhymeResult.threeSyllableRhymes);
         }
-        return new ResultListData<>(mQuery, data);
+        return new ResultListData<>(query, data);
     }
 
-    private ResultListData<RTEntry> emptyResult() {
-        return new ResultListData<>(mQuery, new ArrayList<>());
-    }
-
-    @Override
-    public void deliverResult(ResultListData<RTEntry> data) {
-        Log.d(TAG, "deliverResult() called with: query = " + mQuery + ", filter = " + mFilter + ", data = [" + data + "]");
-        mResult = data;
-        if (isStarted()) super.deliverResult(data);
-    }
-
-    @Override
-    protected void onStartLoading() {
-        super.onStartLoading();
-        Log.d(TAG, "onStartLoading() called with: query = " + mQuery + ", filter = " + mFilter);
-        if (mResult != null) super.deliverResult(mResult);
-        else forceLoad();
+    private ResultListData<RTEntry> emptyResult(String query) {
+        return new ResultListData<>(query, new ArrayList<>());
     }
 
     private void addResultSection(List<RTEntry> results, int sectionHeadingResId, String[] rhymes) {

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLoader.java
@@ -20,7 +20,6 @@
 package ca.rmen.android.poetassistant.main.dictionaries.rt;
 
 import android.content.Context;
-import android.support.v4.content.AsyncTaskLoader;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -32,35 +31,29 @@ import java.util.Set;
 import ca.rmen.android.poetassistant.Constants;
 import ca.rmen.android.poetassistant.R;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListData;
+import ca.rmen.android.poetassistant.main.dictionaries.ResultListLoader;
 
-public class ThesaurusLoader extends AsyncTaskLoader<ResultListData<RTEntry>> {
+public class ThesaurusLoader extends ResultListLoader<ResultListData<RTEntry>> {
 
     private static final String TAG = Constants.TAG + ThesaurusLoader.class.getSimpleName();
 
-    private final String mQuery;
-    private final String mFilter;
-    private ResultListData<RTEntry> mResult;
-
-
-    public ThesaurusLoader(Context context, String query, String filter) {
+    public ThesaurusLoader(Context context) {
         super(context);
-        mQuery = query;
-        mFilter = filter;
     }
 
     @Override
-    public ResultListData<RTEntry> loadInBackground() {
-        Log.d(TAG, "loadInBackground() called with: query = " + mQuery + ", filter = " + mFilter);
+    protected ResultListData<RTEntry> getEntries(String query, String filter) {
+        Log.d(TAG, "getEntries() called with: " + "query = [" + query + "], filter = [" + filter + "]");
 
         Thesaurus thesaurus = Thesaurus.getInstance(getContext());
         List<RTEntry> data = new ArrayList<>();
-        if(TextUtils.isEmpty(mQuery)) return emptyResult();
-        ThesaurusEntry result  = thesaurus.lookup(mQuery);
+        if(TextUtils.isEmpty(query)) return emptyResult(query);
+        ThesaurusEntry result  = thesaurus.lookup(query);
         ThesaurusEntry.ThesaurusEntryDetails[] entries = result.entries;
-        if (entries.length == 0) return emptyResult();
+        if (entries.length == 0) return emptyResult(query);
 
-        if (!TextUtils.isEmpty(mFilter)) {
-            Set<String> rhymes = Rhymer.getInstance(getContext()).getFlatRhymes(mFilter);
+        if (!TextUtils.isEmpty(filter)) {
+            Set<String> rhymes = Rhymer.getInstance(getContext()).getFlatRhymes(filter);
             entries = filter(entries, rhymes);
         }
 
@@ -72,23 +65,8 @@ public class ThesaurusLoader extends AsyncTaskLoader<ResultListData<RTEntry>> {
         return new ResultListData<>(result.word, data);
     }
 
-    private ResultListData<RTEntry> emptyResult() {
-        return new ResultListData<>(mQuery, new ArrayList<>());
-    }
-
-    @Override
-    public void deliverResult(ResultListData<RTEntry> data) {
-        Log.d(TAG, "deliverResult() called with: query = " + mQuery + ", filter = " + mFilter + ", data = [" + data + "]");
-        mResult = data;
-        if (isStarted()) super.deliverResult(data);
-    }
-
-    @Override
-    protected void onStartLoading() {
-        super.onStartLoading();
-        Log.d(TAG, "onStartLoading() called with: query = " + mQuery + ", filter = " + mFilter);
-        if (mResult != null) super.deliverResult(mResult);
-        else forceLoad();
+    private ResultListData<RTEntry> emptyResult(String query) {
+        return new ResultListData<>(query, new ArrayList<>());
     }
 
     private void addResultSection(List<RTEntry> results, int sectionHeadingResId, String[] words) {


### PR DESCRIPTION
I can't wait to add RxJava to my app!

The scope of this PR is limited to just to replace AsyncTaskLoader with RxLoader.  Minimal changes are done to have a minimal diff, to better see where RxLoader logic replaces AsyncTaskLoader logic.

One change in particular is that previously, the ListFragment was creating a new AsyncTaskLoader instance every time a query was performed.  The AsyncTaskLoader constructor had the query arguments. Now, the same RxLoader instance exists throughout the life of the ListFragment, but its main method is invoked with the query arguments.

What I like:
- The RxLoader library is very similar to the support library's Loader API, which makes porting from a standard Loader relatively easy
- The Rx code is split into multiple modular libraries for this to work:
  - **RxJava**: the core of Rx
  - **RxAndroid**: only used for the main thread scheduler
  - **RxLoader**: necessary to easily port the loader-based ListFragment to a ListFragment using Rx to load data. This library saves the day, in particular for managing the rotation of the device.  The Observable which returns the data needs to be maintained outside of the life cycle of the fragment/activity.  I tried initially without this library, but I realized the Observable had to be maintained outside of the fragment lifecycle.  The `RxLoaderManagerCompat` in this library does all the magic.
  - **Retrolambda**: without this, some extra ugly lines of code would be present.
