### PR TITLE
Use a different background color for odd and even rows, in the result list

### DIFF
--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RTEntry.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RTEntry.java
@@ -19,6 +19,8 @@
 
 package ca.rmen.android.poetassistant.main.dictionaries.rt;
 
+import android.support.annotation.ColorInt;
+
 public class RTEntry {
     enum Type {
         HEADING,
@@ -28,10 +30,16 @@ public class RTEntry {
 
     public final Type type;
     public final String text;
+    public final @ColorInt int backgroundColor;
 
     public RTEntry(Type type, String text) {
+        this(type, text, 0);
+    }
+
+    public RTEntry(Type type, String text, @ColorInt int backgroundColor) {
         this.type = type;
         this.text = text;
+        this.backgroundColor = backgroundColor;
     }
 
     @Override

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLoader.java
@@ -20,7 +20,9 @@
 package ca.rmen.android.poetassistant.main.dictionaries.rt;
 
 import android.content.Context;
+import android.support.annotation.ColorRes;
 import android.support.v4.content.AsyncTaskLoader;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -101,8 +103,12 @@ public class RhymerLoader extends AsyncTaskLoader<ResultListData<RTEntry>> {
     private void addResultSection(List<RTEntry> results, int sectionHeadingResId, String[] rhymes) {
         if (rhymes.length > 0) {
             results.add(new RTEntry(RTEntry.Type.SUBHEADING, getContext().getString(sectionHeadingResId)));
-            for (String word : rhymes) {
-                results.add(new RTEntry(RTEntry.Type.WORD, word));
+            for (int i = 0; i < rhymes.length; i++) {
+                @ColorRes int color = (i % 2 == 0)? R.color.row_background_color_even : R.color.row_background_color_odd;
+                results.add(new RTEntry(
+                        RTEntry.Type.WORD,
+                        rhymes[i],
+                        ContextCompat.getColor(getContext(), color)));
             }
         }
     }

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLoader.java
@@ -20,7 +20,9 @@
 package ca.rmen.android.poetassistant.main.dictionaries.rt;
 
 import android.content.Context;
+import android.support.annotation.ColorRes;
 import android.support.v4.content.AsyncTaskLoader;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -94,8 +96,12 @@ public class ThesaurusLoader extends AsyncTaskLoader<ResultListData<RTEntry>> {
     private void addResultSection(List<RTEntry> results, int sectionHeadingResId, String[] words) {
         if (words.length > 0) {
             results.add(new RTEntry(RTEntry.Type.SUBHEADING, getContext().getString(sectionHeadingResId)));
-            for (String word : words) {
-                results.add(new RTEntry(RTEntry.Type.WORD, word));
+            for (int i = 0; i < words.length; i++) {
+                @ColorRes int color = (i % 2 == 0)? R.color.row_background_color_even : R.color.row_background_color_odd;
+                results.add(new RTEntry(
+                        RTEntry.Type.WORD,
+                        words[i],
+                        ContextCompat.getColor(getContext(), color)));
             }
         }
     }

--- a/app/src/main/res/layout/list_item_word.xml
+++ b/app/src/main/res/layout/list_item_word.xml
@@ -33,6 +33,7 @@
     </data>
 
     <RelativeLayout
+        android:background="@{entry.backgroundColor}"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -22,6 +22,6 @@
     <color name="primary_text">#cccccc</color>
     <color name="secondary_text">#727272</color>
     <color name="dialog_accent">@color/accent</color>
-    <color name="row_background_color_even">#383838</color>
-    <color name="row_background_color_odd">#303030</color>
+    <color name="row_background_color_even">@android:color/transparent</color>
+    <color name="row_background_color_odd">@android:color/transparent</color>
 </resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -22,4 +22,6 @@
     <color name="primary_text">#cccccc</color>
     <color name="secondary_text">#727272</color>
     <color name="dialog_accent">@color/accent</color>
+    <color name="row_background_color_even">#383838</color>
+    <color name="row_background_color_odd">#303030</color>
 </resources>

--- a/app/src/main/res/values-sw600dp-night/colors.xml
+++ b/app/src/main/res/values-sw600dp-night/colors.xml
@@ -18,12 +18,6 @@
   -->
 
 <resources>
-    <color name="primary">#607D8B</color>
-    <color name="primary_dark">#455A64</color>
-    <color name="accent">#ffff00</color>
-    <color name="dialog_accent">@color/primary</color>
-    <color name="primary_text">#212121</color>
-    <color name="secondary_text">#727272</color>
-    <color name="row_background_color_even">@android:color/transparent</color>
-    <color name="row_background_color_odd">@android:color/transparent</color>
+    <color name="row_background_color_even">#383838</color>
+    <color name="row_background_color_odd">#303030</color>
 </resources>

--- a/app/src/main/res/values-sw600dp/colors.xml
+++ b/app/src/main/res/values-sw600dp/colors.xml
@@ -18,12 +18,6 @@
   -->
 
 <resources>
-    <color name="primary">#607D8B</color>
-    <color name="primary_dark">#455A64</color>
-    <color name="accent">#ffff00</color>
-    <color name="dialog_accent">@color/primary</color>
-    <color name="primary_text">#212121</color>
-    <color name="secondary_text">#727272</color>
-    <color name="row_background_color_even">@android:color/transparent</color>
-    <color name="row_background_color_odd">@android:color/transparent</color>
+    <color name="row_background_color_even">#ffffff</color>
+    <color name="row_background_color_odd">#f8f8f8</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -24,4 +24,6 @@
     <color name="dialog_accent">@color/primary</color>
     <color name="primary_text">#212121</color>
     <color name="secondary_text">#727272</color>
+    <color name="row_background_color_even">#ffffff</color>
+    <color name="row_background_color_odd">#f8f8f8</color>
 </resources>


### PR DESCRIPTION
![portrait-light](https://cloud.githubusercontent.com/assets/1731388/18617684/e8b59d24-7dd5-11e6-9947-f27f98306105.png)

![landscape-light](https://cloud.githubusercontent.com/assets/1731388/18617688/f4ca4e20-7dd5-11e6-83c7-e2cded4d0676.png)

![portrait-dark](https://cloud.githubusercontent.com/assets/1731388/18617690/fa025536-7dd5-11e6-9c69-19c8a5c0b420.png)

![landscape-dark](https://cloud.githubusercontent.com/assets/1731388/18617691/fe556ab0-7dd5-11e6-9e4b-b818702d04ce.png)
