### PR TITLE
Added a layout setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+1.13.0  *(2017-01-14*)
+--------------------
+* Added a layout setting with two options: "Clean" and "Efficient".
+  -  The "Clean" layout has no RTD buttons: you tap on a word to see a popup with the RTD entries and other actions.
+  -  The "Efficient" layout: you have the RTD buttons to more quickly look up a word, and tapping on a word shows additional actions.
+  -  For selectable text (inside the dictionary + reader): the RTD actions are inserted into the system action popup.
+
 1.12.0  *(2016-12-19)*
 --------------------
 * The word of the day will be the same for everybody on a given day.

--- a/app/src/main/java/ca/rmen/android/poetassistant/DaggerHelper.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/DaggerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -33,6 +33,7 @@ import ca.rmen.android.poetassistant.main.dictionaries.EmbeddedDb;
 import ca.rmen.android.poetassistant.main.dictionaries.Favorites;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListFragment;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListHeaderFragment;
+import ca.rmen.android.poetassistant.main.dictionaries.rt.FavoritesLoader;
 import ca.rmen.android.poetassistant.main.dictionaries.search.Search;
 import ca.rmen.android.poetassistant.main.dictionaries.search.SuggestionsCursor;
 import ca.rmen.android.poetassistant.main.dictionaries.search.SuggestionsProvider;
@@ -79,6 +80,7 @@ public class DaggerHelper {
         void inject(ThesaurusLoader thesaurusLoader);
         void inject(DictionaryLoader dictionaryLoader);
         void inject(PatternLoader patternLoader);
+        void inject(FavoritesLoader favoritesLoader);
         void inject(SuggestionsCursor suggestionsCursor);
         void inject(SuggestionsProvider suggestionsProvider);
         void inject(Favorites favorites);

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/TextPopupMenu.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/TextPopupMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -19,75 +19,189 @@
 
 package ca.rmen.android.poetassistant.main;
 
-import android.text.TextUtils;
+import android.annotation.TargetApi;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ResolveInfo;
+import android.os.Build;
+import android.support.design.widget.Snackbar;
+import android.view.ActionMode;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.SubMenu;
+import android.view.View;
 import android.widget.PopupMenu;
 import android.widget.TextView;
 
+import java.util.List;
+
 import ca.rmen.android.poetassistant.R;
+import ca.rmen.android.poetassistant.main.dictionaries.Share;
 import ca.rmen.android.poetassistant.main.dictionaries.rt.OnWordClickListener;
+import ca.rmen.android.poetassistant.widget.HackFor23381;
 
 public class TextPopupMenu {
+    public enum Style {
+        /**
+         * Denotes popup menu items for looking up a text in the rhymer, thesaurus, or dictionary
+         */
+        APP,
+        /**
+         * Denotes popup menu items for copying text, and any other actions provided by the system.
+         */
+        SYSTEM,
+        /**
+         * Denotes both APP and SYSTEM popup menu items.
+         */
+        FULL
+    }
 
     /**
-     * Create a popup menu allowing the user to lookup the selected word in the given text view, in
+     * Create a popup menu allowing the user perform actions on the whole text of the given text view.
+     *
+     * @param style    determines what popup menu items will appear. See {@link Style}.
+     * @param textView tapping on it will bring up the popup menu
+     * @param listener this listener will be notified when the user selects one of the popup menu items
+     */
+    public static void addPopupMenu(Style style, final TextView textView, final OnWordClickListener listener) {
+        textView.setOnClickListener(v -> {
+            String text = textView.getText().toString();
+            PopupMenu popupMenu = createPopupMenu(textView, text, listener);
+            if (style == Style.APP) {
+                addAppMenuItems(popupMenu);
+            } else if (style == Style.SYSTEM) {
+                addSystemMenuItems(textView.getContext(), popupMenu.getMenuInflater(), popupMenu.getMenu(), text);
+            } else if (style == Style.FULL) {
+                addAppMenuItems(popupMenu);
+                SubMenu systemMenu = popupMenu.getMenu().addSubMenu(R.string.menu_more);
+                addSystemMenuItems(textView.getContext(), popupMenu.getMenuInflater(), systemMenu, text);
+            }
+            popupMenu.show();
+        });
+    }
+
+    /**
+     * Create a popup menu allowing the user to lookup the selected text in the given text view, in
      * the rhymer, thesaurus, or dictionary.
      *
      * @param textView if the text view has selected text, tapping on it will bring up the popup menu
      * @param listener this listener will be notified when the user selects one of the popup menu items
      */
-    public static void createPopupMenu(final TextView textView, final OnWordClickListener listener) {
-        textView.setOnLongClickListener(v -> {
-            final String selectedWord = getSelectedWord(textView);
-            if (TextUtils.isEmpty(selectedWord)) return false;
-            PopupMenu popupMenu = new PopupMenu(textView.getContext(), textView);
-            popupMenu.inflate(R.menu.menu_word_lookup);
-            popupMenu.setOnMenuItemClickListener(item -> {
-                if (item.getItemId() == R.id.action_lookup_rhymer) {
-                    listener.onWordClick(selectedWord, Tab.RHYMER);
-                } else if (item.getItemId() == R.id.action_lookup_thesaurus) {
-                    listener.onWordClick(selectedWord, Tab.THESAURUS);
-                } else if (item.getItemId() == R.id.action_lookup_dictionary) {
-                    listener.onWordClick(selectedWord, Tab.DICTIONARY);
-                }
+    public static void addSelectionPopupMenu(final TextView textView, final OnWordClickListener listener) {
+        textView.setCustomSelectionActionModeCallback(new ActionMode.Callback() {
+            @Override
+            public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+                mode.getMenuInflater().inflate(R.menu.menu_word_lookup, menu);
+                mode.setTitle(null);
+                return true;
+            }
+
+            @Override
+            public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+                // https://code.google.com/p/android/issues/detail?id=23381
+                if (textView instanceof HackFor23381) ((HackFor23381) textView).setWindowFocusWait(true);
                 return false;
-            });
-            popupMenu.show();
-            return true;
+            }
+
+
+            @Override
+            public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+                return handleItemClicked(item.getItemId(), textView, getSelectedWord(textView), listener);
+            }
+
+            @Override
+            public void onDestroyActionMode(ActionMode mode) {
+                // https://code.google.com/p/android/issues/detail?id=23381
+                if (textView instanceof HackFor23381) ((HackFor23381) textView).setWindowFocusWait(false);
+            }
         });
+    }
+
+    private static boolean handleItemClicked(int itemId, View view, String selectedWord, OnWordClickListener listener) {
+        if (itemId == R.id.action_lookup_rhymer) {
+            listener.onWordClick(selectedWord, Tab.RHYMER);
+        } else if (itemId == R.id.action_lookup_thesaurus) {
+            listener.onWordClick(selectedWord, Tab.THESAURUS);
+        } else if (itemId == R.id.action_lookup_dictionary) {
+            listener.onWordClick(selectedWord, Tab.DICTIONARY);
+        } else if (itemId == R.id.action_copy) {
+            ClipboardManager clipboard = (ClipboardManager) view.getContext().getSystemService(Context.CLIPBOARD_SERVICE);
+            ClipData clip = ClipData.newPlainText(selectedWord, selectedWord);
+            clipboard.setPrimaryClip(clip);
+            Snackbar.make(view, R.string.snackbar_copied_text, Snackbar.LENGTH_SHORT).show();
+        } else if (itemId == R.id.action_share) {
+            Share.share(view.getContext(), selectedWord);
+        } else {
+            return false;
+        }
+        return true;
+    }
+
+    private static PopupMenu createPopupMenu(View view, String selectedWord, OnWordClickListener listener) {
+        PopupMenu popupMenu = new PopupMenu(view.getContext(), view);
+        popupMenu.setOnMenuItemClickListener(item -> {
+            handleItemClicked(item.getItemId(), view, selectedWord, listener);
+            return false;
+        });
+        return popupMenu;
+    }
+
+    private static void addAppMenuItems(PopupMenu popupMenu) {
+        popupMenu.inflate(R.menu.menu_word_lookup);
+    }
+
+    private static void addSystemMenuItems(Context context, MenuInflater menuInflater, Menu menu, String text) {
+        menuInflater.inflate(R.menu.menu_word_other, menu);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            for (ResolveInfo resolveInfo : getSupportedActivities(context, text)) {
+                menu.add(R.id.group_system_popup_menu_items, Menu.NONE,
+                        Menu.NONE,
+                        resolveInfo.loadLabel(context.getPackageManager()))
+                        .setIntent(createProcessTextIntentForResolveInfo(resolveInfo, text))
+                        .setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
+            }
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private static List<ResolveInfo> getSupportedActivities(Context context, String text) {
+        //https://android-developers.googleblog.com/2015/10/in-app-translations-in-android.html?hl=mk
+        return context.getPackageManager().queryIntentActivities(createProcessTextIntent(text), 0);
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private static Intent createProcessTextIntent(String text) {
+        //https://android-developers.googleblog.com/2015/10/in-app-translations-in-android.html?hl=mk
+        return new Intent()
+                .setAction(Intent.ACTION_PROCESS_TEXT)
+                .putExtra(Intent.EXTRA_PROCESS_TEXT, text)
+                .setType("text/plain");
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private static Intent createProcessTextIntentForResolveInfo(ResolveInfo info, String text) {
+        //https://android-developers.googleblog.com/2015/10/in-app-translations-in-android.html?hl=mk
+        return createProcessTextIntent(text)
+                .putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, true)
+                .setClassName(info.activityInfo.packageName,
+                        info.activityInfo.name);
     }
 
     private static String getSelectedWord(TextView textView) {
         int selectionStart = textView.getSelectionStart();
         int selectionEnd = textView.getSelectionEnd();
-        String text = textView.getText().toString();
 
         // The user selected some text, use that (even if it contains partial words)
-        if (selectionStart < selectionEnd) return text.substring(selectionStart, selectionEnd);
-
-        // Cursor at the end of the text: nothing selected
-        if (selectionStart == text.length()) return null;
-
-        // Cursor at the beginning of the text: nothing selected
-        if (selectionStart == 0 && selectionEnd == 0) return null;
-
-        // The cursor is in the middle of a word. Find the whole word.
-        int wordBegin;
-        for (wordBegin = selectionStart; wordBegin >= 0; wordBegin--) {
-            if (!Character.isLetter(text.charAt(wordBegin))) {
-                break;
-            }
-        }
-        wordBegin++;
-        int wordEnd;
-        for (wordEnd = selectionEnd; wordEnd < text.length(); wordEnd++) {
-            if (!Character.isLetter(text.charAt(wordEnd))) {
-                break;
-            }
+        if (selectionStart < selectionEnd) {
+            String text = textView.getText().toString();
+            return text.substring(selectionStart, selectionEnd);
         }
 
-        if (wordBegin < wordEnd) return text.substring(wordBegin, wordEnd);
         return null;
     }
-
 
 }

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/Share.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/Share.java
@@ -29,7 +29,7 @@ import ca.rmen.android.poetassistant.Constants;
 import ca.rmen.android.poetassistant.R;
 import ca.rmen.android.poetassistant.main.Tab;
 
-final class Share {
+public final class Share {
     private static final String TAG = Constants.TAG + Share.class.getSimpleName();
 
     private Share() {
@@ -49,6 +49,16 @@ final class Share {
         ResultListExporter<T> exporter = (ResultListExporter<T>) ResultListFactory.createExporter(context, tab);
         String text = exporter.export(word, filter, entries);
         Log.v(TAG, "Will share " + text);
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.putExtra(Intent.EXTRA_TEXT, text);
+        intent.setType("text/plain");
+        context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)));
+    }
+
+    /**
+     * Allows the user to share the given text.
+     */
+    public static void share(Context context, @NonNull String text) {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.putExtra(Intent.EXTRA_TEXT, text);
         intent.setType("text/plain");

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/dictionary/DictionaryListAdapter.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/dictionary/DictionaryListAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -52,7 +52,7 @@ public class DictionaryListAdapter extends ResultListAdapter<DictionaryEntry.Dic
     public void onBindViewHolder(ResultListAdapter.ResultListEntryViewHolder holder, int position) {
         DictionaryEntry.DictionaryEntryDetails entry = getItem(position);
         ListItemDictionaryEntryBinding binding = (ListItemDictionaryEntryBinding) holder.binding;
-        TextPopupMenu.createPopupMenu(binding.definition, mListener);
+        TextPopupMenu.addSelectionPopupMenu(binding.definition,  mListener);
         binding.setEntry(entry);
         binding.executePendingBindings();
     }

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/FavoritesLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/FavoritesLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -29,17 +29,24 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javax.inject.Inject;
+
 import ca.rmen.android.poetassistant.Constants;
+import ca.rmen.android.poetassistant.DaggerHelper;
 import ca.rmen.android.poetassistant.R;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListData;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListLoader;
+import ca.rmen.android.poetassistant.settings.Settings;
+import ca.rmen.android.poetassistant.settings.SettingsPrefs;
 
 public class FavoritesLoader extends ResultListLoader<ResultListData<RTEntry>> {
 
     private static final String TAG = Constants.TAG + FavoritesLoader.class.getSimpleName();
 
+    @Inject SettingsPrefs mPrefs;
     public FavoritesLoader(Context context) {
         super(context);
+        DaggerHelper.getAppComponent(context).inject(this);
     }
 
     @Override
@@ -52,6 +59,7 @@ public class FavoritesLoader extends ResultListLoader<ResultListData<RTEntry>> {
         if (favorites.isEmpty()) return emptyResult();
 
         TreeSet<String> sortedFavorites = new TreeSet<>(favorites);
+        Settings.Layout layout = Settings.getLayout(mPrefs);
         int i = 0;
         for (String favorite : sortedFavorites) {
             @ColorRes int color = (i % 2 == 0)? R.color.row_background_color_even : R.color.row_background_color_odd;
@@ -59,7 +67,8 @@ public class FavoritesLoader extends ResultListLoader<ResultListData<RTEntry>> {
                     RTEntry.Type.WORD,
                     favorite,
                     ContextCompat.getColor(getContext(), color),
-                    true));
+                    true,
+                    layout == Settings.Layout.EFFICIENT));
             i++;
         }
         return new ResultListData<>(getContext().getString(R.string.favorites_list_header), false, data);

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/PatternLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/PatternLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -40,6 +40,8 @@ import ca.rmen.android.poetassistant.main.dictionaries.search.Patterns;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListData;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListLoader;
 import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary;
+import ca.rmen.android.poetassistant.settings.Settings;
+import ca.rmen.android.poetassistant.settings.SettingsPrefs;
 
 public class PatternLoader extends ResultListLoader<ResultListData<RTEntry>> {
 
@@ -47,6 +49,7 @@ public class PatternLoader extends ResultListLoader<ResultListData<RTEntry>> {
 
     private final String mQuery;
     @Inject Dictionary mDictionary;
+    @Inject SettingsPrefs mPrefs;
 
     public PatternLoader(Context context, String query) {
         super(context);
@@ -72,13 +75,15 @@ public class PatternLoader extends ResultListLoader<ResultListData<RTEntry>> {
             Arrays.sort(matches, new MatchComparator(favorites));
         }
 
+        Settings.Layout layout = Settings.getLayout(mPrefs);
         for (int i=0; i < matches.length; i++) {
             @ColorRes int color = (i % 2 == 0)? R.color.row_background_color_even : R.color.row_background_color_odd;
             data.add(new RTEntry(
                     RTEntry.Type.WORD,
                     matches[i],
                     ContextCompat.getColor(getContext(), color),
-                    favorites.contains(matches[i])));
+                    favorites.contains(matches[i]),
+                    layout == Settings.Layout.EFFICIENT));
         }
         if (matches.length == Patterns.MAX_RESULTS) {
             data.add(new RTEntry(

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RTEntry.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RTEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -33,21 +33,23 @@ public class RTEntry {
     public final @ColorInt int backgroundColor;
     public final boolean isFavorite;
     public final boolean hasDefinition;
+    public final boolean showButtons;
 
     public RTEntry(Type type, String text) {
-        this(type, text, 0, false);
+        this(type, text, 0, false, false);
     }
 
-    public RTEntry(Type type, String text, @ColorInt int backgroundColor, boolean isFavorite) {
-        this(type, text, backgroundColor, isFavorite, true);
+    public RTEntry(Type type, String text, @ColorInt int backgroundColor, boolean isFavorite, boolean showButtons) {
+        this(type, text, backgroundColor, isFavorite, true, showButtons);
     }
 
-    public RTEntry(Type type, String text, @ColorInt int backgroundColor, boolean isFavorite, boolean hasDefinition) {
+    public RTEntry(Type type, String text, @ColorInt int backgroundColor, boolean isFavorite, boolean hasDefinition, boolean showButtons) {
         this.type = type;
         this.text = text;
         this.backgroundColor = backgroundColor;
         this.isFavorite = isFavorite;
         this.hasDefinition = hasDefinition;
+        this.showButtons = showButtons;
     }
 
     @Override

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RTListAdapter.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RTListAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -32,6 +32,7 @@ import ca.rmen.android.poetassistant.databinding.ListItemHeadingBinding;
 import ca.rmen.android.poetassistant.databinding.ListItemSubheadingBinding;
 import ca.rmen.android.poetassistant.databinding.ListItemWordBinding;
 import ca.rmen.android.poetassistant.main.Tab;
+import ca.rmen.android.poetassistant.main.TextPopupMenu;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListAdapter;
 
 
@@ -79,9 +80,13 @@ public class RTListAdapter extends ResultListAdapter<RTEntry> {
         } else if (entry.type == RTEntry.Type.SUBHEADING) {
             ((ListItemSubheadingBinding) holder.binding).setEntry(entry);
         } else {
-            ((ListItemWordBinding) holder.binding).setEntry(entry);
-            ((ListItemWordBinding) holder.binding).setEntryIconClickListener(mEntryIconClickListener);
-            ((ListItemWordBinding) holder.binding).btnStarResult.setChecked(entry.isFavorite);
+            ListItemWordBinding wordBinding = (ListItemWordBinding) holder.binding;
+            wordBinding.setEntry(entry);
+            wordBinding.setEntryIconClickListener(mEntryIconClickListener);
+            TextPopupMenu.addPopupMenu(
+                    entry.showButtons ? TextPopupMenu.Style.SYSTEM : TextPopupMenu.Style.FULL,
+                    wordBinding.text1,
+                    mWordClickedListener);
         }
         holder.binding.executePendingBindings();
     }
@@ -89,14 +94,14 @@ public class RTListAdapter extends ResultListAdapter<RTEntry> {
     public class EntryIconClickListener {
 
         private String getWord(View v) {
-            ListItemWordBinding binding = DataBindingUtil.getBinding((View)v.getParent());
+            ListItemWordBinding binding = DataBindingUtil.getBinding((View) v.getParent());
             return binding.text1.getText().toString();
         }
 
         public void onFavoriteIconClicked(View v) {
-            mOnFavoriteClickListener.onFavoriteToggled(getWord(v), ((CheckBox)v).isChecked());
-
+            mOnFavoriteClickListener.onFavoriteToggled(getWord(v), ((CheckBox) v).isChecked());
         }
+
         public void onRhymerIconClicked(View v) {
             mWordClickedListener.onWordClick(getWord(v), Tab.RHYMER);
         }

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -37,6 +37,7 @@ import ca.rmen.android.poetassistant.DaggerHelper;
 import ca.rmen.android.poetassistant.R;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListData;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListLoader;
+import ca.rmen.android.poetassistant.settings.Settings;
 import ca.rmen.android.poetassistant.settings.SettingsPrefs;
 import ca.rmen.rhymer.RhymeResult;
 
@@ -74,9 +75,10 @@ public class RhymerLoader extends ResultListLoader<ResultListData<RTEntry>> {
             if (synonyms.isEmpty()) return emptyResult();
             rhymeResults = filter(rhymeResults, synonyms);
         }
+        Settings.Layout layout = Settings.getLayout(mPrefs);
         Set<String> favorites = mFavorites.getFavorites();
         if (!favorites.isEmpty()) {
-            addResultSection(favorites, data, R.string.rhyme_section_favorites, getMatchingFavorites(rhymeResults, favorites));
+            addResultSection(favorites, data, R.string.rhyme_section_favorites, getMatchingFavorites(rhymeResults, favorites), layout);
         }
         for (RhymeResult rhymeResult : rhymeResults) {
             // Add the word variant, if there are multiple pronunciations.
@@ -85,10 +87,10 @@ public class RhymerLoader extends ResultListLoader<ResultListData<RTEntry>> {
                 data.add(new RTEntry(RTEntry.Type.HEADING, heading));
             }
 
-            addResultSection(favorites, data, R.string.rhyme_section_stress_syllables, rhymeResult.strictRhymes);
-            addResultSection(favorites, data, R.string.rhyme_section_three_syllables, rhymeResult.threeSyllableRhymes);
-            addResultSection(favorites, data, R.string.rhyme_section_two_syllables, rhymeResult.twoSyllableRhymes);
-            addResultSection(favorites, data, R.string.rhyme_section_one_syllable, rhymeResult.oneSyllableRhymes);
+            addResultSection(favorites, data, R.string.rhyme_section_stress_syllables, rhymeResult.strictRhymes, layout);
+            addResultSection(favorites, data, R.string.rhyme_section_three_syllables, rhymeResult.threeSyllableRhymes, layout);
+            addResultSection(favorites, data, R.string.rhyme_section_two_syllables, rhymeResult.twoSyllableRhymes, layout);
+            addResultSection(favorites, data, R.string.rhyme_section_one_syllable, rhymeResult.oneSyllableRhymes, layout);
         }
         ResultListData<RTEntry> result = new ResultListData<>(mQuery, favorites.contains(mQuery), data);
         long after = System.currentTimeMillis();
@@ -127,7 +129,7 @@ public class RhymerLoader extends ResultListLoader<ResultListData<RTEntry>> {
         return new ResultListData<>(mQuery, false, new ArrayList<>());
     }
 
-    private void addResultSection(Set<String> favorites, List<RTEntry> results, int sectionHeadingResId, String[] rhymes) {
+    private void addResultSection(Set<String> favorites, List<RTEntry> results, int sectionHeadingResId, String[] rhymes, Settings.Layout layout) {
         if (rhymes.length > 0) {
 
             Set<String> wordsWithDefinitions = mPrefs.getIsAllRhymesEnabled() ? mRhymer.getWordsWithDefinitions(rhymes) : null;
@@ -140,7 +142,8 @@ public class RhymerLoader extends ResultListLoader<ResultListData<RTEntry>> {
                         rhymes[i],
                         ContextCompat.getColor(getContext(), color),
                         favorites.contains(rhymes[i]),
-                        hasDefinition));
+                        hasDefinition,
+                        layout == Settings.Layout.EFFICIENT));
             }
         }
     }

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -37,6 +37,8 @@ import ca.rmen.android.poetassistant.DaggerHelper;
 import ca.rmen.android.poetassistant.R;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListData;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListLoader;
+import ca.rmen.android.poetassistant.settings.Settings;
+import ca.rmen.android.poetassistant.settings.SettingsPrefs;
 
 public class ThesaurusLoader extends ResultListLoader<ResultListData<RTEntry>> {
 
@@ -44,6 +46,7 @@ public class ThesaurusLoader extends ResultListLoader<ResultListData<RTEntry>> {
 
     @Inject Rhymer mRhymer;
     @Inject Thesaurus mThesaurus;
+    @Inject SettingsPrefs mPrefs;
     private final String mQuery;
     private final String mFilter;
 
@@ -69,11 +72,12 @@ public class ThesaurusLoader extends ResultListLoader<ResultListData<RTEntry>> {
             entries = filter(entries, rhymes);
         }
 
+        Settings.Layout layout = Settings.getLayout(mPrefs);
         Set<String> favorites = mFavorites.getFavorites();
         for (ThesaurusEntry.ThesaurusEntryDetails entry : entries) {
             data.add(new RTEntry(RTEntry.Type.HEADING, entry.wordType.name().toLowerCase(Locale.US)));
-            addResultSection(favorites, data, R.string.thesaurus_section_synonyms, entry.synonyms);
-            addResultSection(favorites, data, R.string.thesaurus_section_antonyms, entry.antonyms);
+            addResultSection(favorites, data, R.string.thesaurus_section_synonyms, entry.synonyms, layout);
+            addResultSection(favorites, data, R.string.thesaurus_section_antonyms, entry.antonyms, layout);
         }
         return new ResultListData<>(result.word, favorites.contains(result.word), data);
     }
@@ -82,7 +86,7 @@ public class ThesaurusLoader extends ResultListLoader<ResultListData<RTEntry>> {
         return new ResultListData<>(mQuery, false, new ArrayList<>());
     }
 
-    private void addResultSection(Set<String> favorites, List<RTEntry> results, int sectionHeadingResId, String[] words) {
+    private void addResultSection(Set<String> favorites, List<RTEntry> results, int sectionHeadingResId, String[] words, Settings.Layout layout) {
         if (words.length > 0) {
             results.add(new RTEntry(RTEntry.Type.SUBHEADING, getContext().getString(sectionHeadingResId)));
             for (int i = 0; i < words.length; i++) {
@@ -91,7 +95,8 @@ public class ThesaurusLoader extends ResultListLoader<ResultListData<RTEntry>> {
                         RTEntry.Type.WORD,
                         words[i],
                         ContextCompat.getColor(getContext(), color),
-                        favorites.contains(words[i])));
+                        favorites.contains(words[i]),
+                        layout == Settings.Layout.EFFICIENT));
             }
         }
     }

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/reader/ReaderFragment.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/reader/ReaderFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -108,7 +108,7 @@ public class ReaderFragment extends Fragment implements
         mBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_reader, container, false);
         mBinding.setPlayButtonListener(mPlayButtonListener);
         mBinding.tvText.addTextChangedListener(mTextWatcher);
-        TextPopupMenu.createPopupMenu(mBinding.tvText, (OnWordClickListener) getActivity());
+        TextPopupMenu.addSelectionPopupMenu(mBinding.tvText, (OnWordClickListener) getActivity());
         mHandler = new Handler();
         return mBinding.getRoot();
     }

--- a/app/src/main/java/ca/rmen/android/poetassistant/settings/Settings.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/settings/Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -29,6 +29,8 @@ import org.jraf.android.prefs.DefaultString;
 import org.jraf.android.prefs.Name;
 import org.jraf.android.prefs.Prefs;
 
+import java.util.Locale;
+
 @Prefs
 public class Settings {
     @SuppressWarnings("unused")
@@ -41,6 +43,7 @@ public class Settings {
     // v2 is a float between 0 and 200
     public static final String PREF_VOICE_SPEED = "PREF_VOICE_SPEED_V3";
     public static final String PREF_VOICE_PITCH = "PREF_VOICE_PITCH_V3";
+    public static final String PREF_LAYOUT = "PREF_LAYOUT";
     @SuppressWarnings("unused")
     private static final int VOICE_SPEED_NORMAL = 100;
     @SuppressWarnings("unused")
@@ -69,6 +72,11 @@ public class Settings {
     @SuppressWarnings("unused")
     @Name(PREF_THEME)
     String theme;
+
+    @SuppressWarnings("unused")
+    @Name(PREF_LAYOUT)
+    @DefaultString("Efficient")
+    String layout;
 
     @SuppressWarnings("unused")
     @Name(PREF_WOTD_ENABLED)
@@ -111,6 +119,15 @@ public class Settings {
                     .apply();
 
         }
+    }
+
+    public static Layout getLayout(SettingsPrefs prefs) {
+        return Layout.valueOf(prefs.getLayout().toUpperCase(Locale.US));
+    }
+
+    public enum Layout {
+        @SuppressWarnings("unused")CLEAN,
+        EFFICIENT
     }
 
 }

--- a/app/src/main/java/ca/rmen/android/poetassistant/widget/CABEditText.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/widget/CABEditText.java
@@ -1,0 +1,36 @@
+package ca.rmen.android.poetassistant.widget;
+
+import android.content.Context;
+import android.support.v7.widget.AppCompatEditText;
+import android.util.AttributeSet;
+
+/**
+ * https://code.google.com/p/android/issues/detail?id=23381
+ */
+public class CABEditText extends AppCompatEditText implements HackFor23381 {
+    private boolean shouldWindowFocusWait;
+
+    public CABEditText(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public CABEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public CABEditText(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void setWindowFocusWait(boolean shouldWindowFocusWait) {
+        this.shouldWindowFocusWait = shouldWindowFocusWait;
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasWindowFocus) {
+        if(!shouldWindowFocusWait) {
+            super.onWindowFocusChanged(hasWindowFocus);
+        }
+    }
+}

--- a/app/src/main/java/ca/rmen/android/poetassistant/widget/CABTextView.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/widget/CABTextView.java
@@ -1,0 +1,36 @@
+package ca.rmen.android.poetassistant.widget;
+
+import android.content.Context;
+import android.support.v7.widget.AppCompatTextView;
+import android.util.AttributeSet;
+
+/**
+ * https://code.google.com/p/android/issues/detail?id=23381
+ */
+public class CABTextView extends AppCompatTextView implements HackFor23381 {
+    private boolean shouldWindowFocusWait;
+
+    public CABTextView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public CABTextView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public CABTextView(Context context) {
+        super(context);
+    }
+
+    @Override
+    public void setWindowFocusWait(boolean shouldWindowFocusWait) {
+        this.shouldWindowFocusWait = shouldWindowFocusWait;
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasWindowFocus) {
+        if(!shouldWindowFocusWait) {
+            super.onWindowFocusChanged(hasWindowFocus);
+        }
+    }
+}

--- a/app/src/main/java/ca/rmen/android/poetassistant/widget/HackFor23381.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/widget/HackFor23381.java
@@ -1,0 +1,8 @@
+package ca.rmen.android.poetassistant.widget;
+
+/**
+ * https://code.google.com/p/android/issues/detail?id=23381
+ */
+public interface HackFor23381 {
+    void setWindowFocusWait(boolean shouldWindowFocusWait);
+}

--- a/app/src/main/java/ca/rmen/android/poetassistant/wotd/WotdAdapter.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/wotd/WotdAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -29,10 +29,10 @@ import android.widget.CheckBox;
 import ca.rmen.android.poetassistant.R;
 import ca.rmen.android.poetassistant.databinding.ListItemWotdBinding;
 import ca.rmen.android.poetassistant.main.Tab;
+import ca.rmen.android.poetassistant.main.TextPopupMenu;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListAdapter;
 import ca.rmen.android.poetassistant.main.dictionaries.rt.OnFavoriteClickListener;
 import ca.rmen.android.poetassistant.main.dictionaries.rt.OnWordClickListener;
-
 
 public class WotdAdapter extends ResultListAdapter<WotdEntry> {
 
@@ -67,6 +67,10 @@ public class WotdAdapter extends ResultListAdapter<WotdEntry> {
         ListItemWotdBinding binding = (ListItemWotdBinding) holder.binding;
         binding.setEntry(entry);
         binding.setEntryIconClickListener(mEntryIconClickListener);
+        TextPopupMenu.addPopupMenu(
+                entry.showButtons ? TextPopupMenu.Style.SYSTEM : TextPopupMenu.Style.FULL,
+                binding.text1,
+                mWordClickedListener);
         binding.executePendingBindings();
     }
 

--- a/app/src/main/java/ca/rmen/android/poetassistant/wotd/WotdEntry.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/wotd/WotdEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -27,11 +27,13 @@ public final class WotdEntry {
     public final String date;
     public final @ColorInt int backgroundColor;
     public final boolean isFavorite;
+    public final boolean showButtons;
 
-    public WotdEntry(String text, String date, @ColorInt int backgroundColor, boolean isFavorite) {
+    public WotdEntry(String text, String date, @ColorInt int backgroundColor, boolean isFavorite, boolean showButtons) {
         this.text = text;
         this.date = date;
         this.backgroundColor = backgroundColor;
         this.isFavorite = isFavorite;
+        this.showButtons = showButtons;
     }
 }

--- a/app/src/main/java/ca/rmen/android/poetassistant/wotd/WotdLoader.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/wotd/WotdLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Carmen Alvarez
+ * Copyright (c) 2016-2017 Carmen Alvarez
  *
  * This file is part of Poet Assistant.
  *
@@ -42,13 +42,15 @@ import ca.rmen.android.poetassistant.main.dictionaries.Favorites;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListData;
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListLoader;
 import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary;
+import ca.rmen.android.poetassistant.settings.Settings;
+import ca.rmen.android.poetassistant.settings.SettingsPrefs;
 
 public class WotdLoader extends ResultListLoader<ResultListData<WotdEntry>> {
 
     private static final String TAG = Constants.TAG + WotdLoader.class.getSimpleName();
 
-    @Inject
-    Dictionary mDictionary;
+    @Inject Dictionary mDictionary;
+    @Inject SettingsPrefs mPrefs;
 
     public WotdLoader(Context context) {
         super(context);
@@ -69,6 +71,7 @@ public class WotdLoader extends ResultListLoader<ResultListData<WotdEntry>> {
             Calendar calendar = Wotd.getTodayUTC();
             Calendar calendarDisplay = Wotd.getTodayUTC();
             calendarDisplay.setTimeZone(TimeZone.getDefault());
+            Settings.Layout layout = Settings.getLayout(mPrefs);
             for (int i = 0; i < 100; i++) {
                 Random random = new Random();
                 random.setSeed(calendar.getTimeInMillis());
@@ -83,7 +86,8 @@ public class WotdLoader extends ResultListLoader<ResultListData<WotdEntry>> {
                             word,
                             date,
                             ContextCompat.getColor(getContext(), color),
-                            favorites.contains(word)));
+                            favorites.contains(word),
+                            layout == Settings.Layout.EFFICIENT));
                 }
                 calendar.add(Calendar.DAY_OF_YEAR, -1);
                 calendarDisplay.add(Calendar.DAY_OF_YEAR, -1);

--- a/app/src/main/res/layout/fragment_reader.xml
+++ b/app/src/main/res/layout/fragment_reader.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Carmen Alvarez
+  ~ Copyright (c) 2016-2017 Carmen Alvarez
   ~
   ~ This file is part of Poet Assistant.
   ~
@@ -51,7 +51,7 @@
                 android:onClick="@{playButtonListener.onPlayButtonClicked}"
                 app:srcCompat="@drawable/ic_play_disabled" />
 
-            <EditText
+            <ca.rmen.android.poetassistant.widget.CABEditText
                 android:id="@+id/tv_text"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/list_item_dictionary_entry.xml
+++ b/app/src/main/res/layout/list_item_dictionary_entry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2016 Carmen Alvarez
+  ~ Copyright (c) 2016-2017 Carmen Alvarez
   ~
   ~ This file is part of Poet Assistant.
   ~
@@ -45,7 +45,7 @@
             android:textStyle="bold"
             tools:text="v" />
 
-        <TextView
+        <ca.rmen.android.poetassistant.widget.CABTextView
             android:id="@+id/definition"
             style="?attr/textAppearanceListItem"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/list_item_word.xml
+++ b/app/src/main/res/layout/list_item_word.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2016 Carmen Alvarez
+  ~ Copyright (c) 2016-2017 Carmen Alvarez
   ~
   ~ This file is part of Poet Assistant.
   ~
@@ -33,15 +33,17 @@
             type="ca.rmen.android.poetassistant.main.dictionaries.rt.RTEntry" />
     </data>
 
-    <RelativeLayout
+    <LinearLayout
         android:background="@{entry.backgroundColor}"
+        android:orientation="horizontal"
         android:gravity="center_vertical"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/list_rt_item_word_height">
+        android:layout_height="?attr/listPreferredItemHeightSmall">
 
         <CheckBox
             android:background="?selectableItemBackgroundBorderless"
             android:button="@drawable/ic_star"
+            android:checked="@{entry.isFavorite}"
             android:clickable="true"
             android:id="@+id/btn_star_result"
             android:layout_marginLeft="8dp"
@@ -50,24 +52,19 @@
             android:paddingStart="4dp"
             android:paddingRight="8dp"
             android:paddingEnd="8dp"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_centerVertical="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:onClick="@{entryIconClickListener.onFavoriteIconClicked}" />
         <TextView
             android:id="@+id/text1"
             style="?attr/textAppearanceListItem"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_toRightOf="@id/btn_star_result"
-            android:layout_toEndOf="@id/btn_star_result"
-            android:layout_toLeftOf="@+id/btn_rhymer"
-            android:layout_toStartOf="@+id/btn_rhymer"
+            android:clickable="true"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
             android:text="@{entry.text}"
-            android:textIsSelectable="true"
             tools:text="happy" />
 
         <!--
@@ -78,12 +75,9 @@
              http://stackoverflow.com/questions/35624562/code-analysis-error-unexpected-namespace-prefix-after-upgrading-android-suppor
         -->
         <android.support.v7.widget.AppCompatImageView
-            android:id="@id/btn_rhymer"
+            android:id="@+id/btn_rhymer"
             android:layout_width="@dimen/list_rtd_icon_size"
             android:layout_height="@dimen/list_rtd_icon_size"
-            android:layout_centerVertical="true"
-            android:layout_toLeftOf="@+id/btn_thesaurus"
-            android:layout_toStartOf="@id/btn_thesaurus"
             android:background="?selectableItemBackgroundBorderless"
             android:clickable="true"
             android:contentDescription="@string/tab_rhymer"
@@ -92,15 +86,13 @@
             android:paddingRight="@dimen/list_rtd_icon_padding"
             android:paddingStart="@dimen/list_rtd_icon_padding"
             android:paddingEnd="@dimen/list_rtd_icon_padding"
+            android:visibility="@{entry.showButtons? View.VISIBLE:View.GONE}"
             app:srcCompat="@drawable/ic_rhymer" />
 
         <android.support.v7.widget.AppCompatImageView
-            android:id="@id/btn_thesaurus"
+            android:id="@+id/btn_thesaurus"
             android:layout_width="@dimen/list_rtd_icon_size"
             android:layout_height="@dimen/list_rtd_icon_size"
-            android:layout_centerVertical="true"
-            android:layout_toLeftOf="@+id/btn_dictionary"
-            android:layout_toStartOf="@+id/btn_dictionary"
             android:background="?selectableItemBackgroundBorderless"
             android:clickable="@{entry.hasDefinition}"
             android:contentDescription="@string/tab_thesaurus"
@@ -110,15 +102,13 @@
             android:paddingStart="@dimen/list_rtd_icon_padding"
             android:paddingEnd="@dimen/list_rtd_icon_padding"
             android:alpha="@{entry.hasDefinition ? 0xff: 0x44}"
+            android:visibility="@{entry.showButtons? View.VISIBLE:View.GONE}"
             app:srcCompat="@drawable/ic_thesaurus" />
 
         <android.support.v7.widget.AppCompatImageView
-            android:id="@id/btn_dictionary"
+            android:id="@+id/btn_dictionary"
             android:layout_width="@dimen/list_rtd_icon_size"
             android:layout_height="@dimen/list_rtd_icon_size"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
             android:layout_marginEnd="16dp"
             android:layout_marginRight="16dp"
             android:background="?selectableItemBackgroundBorderless"
@@ -130,7 +120,8 @@
             android:contentDescription="@string/tab_dictionary"
             android:onClick="@{entryIconClickListener.onDictionaryIconClicked}"
             android:alpha="@{entry.hasDefinition ? 0xff: 0x44}"
+            android:visibility="@{entry.showButtons? View.VISIBLE:View.GONE}"
             app:srcCompat="@drawable/ic_dictionary" />
 
-    </RelativeLayout>
+    </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/list_item_wotd.xml
+++ b/app/src/main/res/layout/list_item_wotd.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2016 Carmen Alvarez
+  ~ Copyright (c) 2016-2017 Carmen Alvarez
   ~
   ~ This file is part of Poet Assistant.
   ~
@@ -35,27 +35,25 @@
     </data>
 
 
-    <RelativeLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="?attr/listPreferredItemHeight"
         android:layout_gravity="center_vertical"
         android:background="@{entry.backgroundColor}"
-        android:gravity="center_vertical">
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
 
         <CheckBox
             android:id="@+id/btn_star_result"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_centerVertical="true"
             android:layout_marginLeft="8dp"
             android:layout_marginStart="8dp"
             android:background="?selectableItemBackgroundBorderless"
             android:button="@drawable/ic_star"
-            android:clickable="true"
             android:checked="@{entry.isFavorite}"
+            android:clickable="true"
             android:onClick="@{entryIconClickListener.onFavoriteIconClicked}"
             android:paddingEnd="8dp"
             android:paddingLeft="4dp"
@@ -63,13 +61,9 @@
             android:paddingStart="4dp" />
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_centerVertical="true"
-            android:layout_toEndOf="@id/btn_star_result"
-            android:layout_toLeftOf="@+id/btn_rhymer"
-            android:layout_toRightOf="@id/btn_star_result"
-            android:layout_toStartOf="@+id/btn_rhymer"
+            android:layout_weight="1"
             android:gravity="center_vertical"
             android:orientation="vertical">
 
@@ -88,10 +82,10 @@
             <TextView
                 android:id="@+id/text1"
                 style="?attr/textAppearanceListItem"
-                android:layout_width="wrap_content"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@{entry.text}"
-                android:textIsSelectable="true"
                 tools:text="happy" />
 
         </LinearLayout>
@@ -104,12 +98,9 @@
              http://stackoverflow.com/questions/35624562/code-analysis-error-unexpected-namespace-prefix-after-upgrading-android-suppor
         -->
         <android.support.v7.widget.AppCompatImageView
-            android:id="@id/btn_rhymer"
+            android:id="@+id/btn_rhymer"
             android:layout_width="@dimen/list_rtd_icon_size"
             android:layout_height="@dimen/list_rtd_icon_size"
-            android:layout_centerVertical="true"
-            android:layout_toLeftOf="@+id/btn_thesaurus"
-            android:layout_toStartOf="@id/btn_thesaurus"
             android:background="?selectableItemBackgroundBorderless"
             android:clickable="true"
             android:contentDescription="@string/tab_rhymer"
@@ -118,15 +109,13 @@
             android:paddingLeft="@dimen/list_rtd_icon_padding"
             android:paddingRight="@dimen/list_rtd_icon_padding"
             android:paddingStart="@dimen/list_rtd_icon_padding"
+            android:visibility="@{entry.showButtons? View.VISIBLE:View.GONE}"
             app:srcCompat="@drawable/ic_rhymer" />
 
         <android.support.v7.widget.AppCompatImageView
-            android:id="@id/btn_thesaurus"
+            android:id="@+id/btn_thesaurus"
             android:layout_width="@dimen/list_rtd_icon_size"
             android:layout_height="@dimen/list_rtd_icon_size"
-            android:layout_centerVertical="true"
-            android:layout_toLeftOf="@+id/btn_dictionary"
-            android:layout_toStartOf="@+id/btn_dictionary"
             android:background="?selectableItemBackgroundBorderless"
             android:contentDescription="@string/tab_thesaurus"
             android:onClick="@{entryIconClickListener.onThesaurusIconClicked}"
@@ -134,15 +123,13 @@
             android:paddingLeft="@dimen/list_rtd_icon_padding"
             android:paddingRight="@dimen/list_rtd_icon_padding"
             android:paddingStart="@dimen/list_rtd_icon_padding"
+            android:visibility="@{entry.showButtons? View.VISIBLE:View.GONE}"
             app:srcCompat="@drawable/ic_thesaurus" />
 
         <android.support.v7.widget.AppCompatImageView
-            android:id="@id/btn_dictionary"
+            android:id="@+id/btn_dictionary"
             android:layout_width="@dimen/list_rtd_icon_size"
             android:layout_height="@dimen/list_rtd_icon_size"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
             android:layout_marginEnd="16dp"
             android:layout_marginRight="16dp"
             android:background="?selectableItemBackgroundBorderless"
@@ -152,7 +139,8 @@
             android:paddingLeft="@dimen/list_rtd_icon_padding"
             android:paddingRight="@dimen/list_rtd_icon_padding"
             android:paddingStart="@dimen/list_rtd_icon_padding"
+            android:visibility="@{entry.showButtons? View.VISIBLE:View.GONE}"
             app:srcCompat="@drawable/ic_dictionary" />
 
-    </RelativeLayout>
+    </LinearLayout>
 </layout>

--- a/app/src/main/res/menu/menu_word_lookup.xml
+++ b/app/src/main/res/menu/menu_word_lookup.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Carmen Alvarez
+  ~ Copyright (c) 2016-2017 Carmen Alvarez
   ~
   ~ This file is part of Poet Assistant.
   ~
@@ -20,13 +20,14 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".main.MainActivity">
-    <item
-        android:id="@+id/action_lookup_rhymer"
-        android:title="@string/menu_lookup_rhymer" />
-    <item
-        android:id="@+id/action_lookup_thesaurus"
-        android:title="@string/menu_lookup_thesaurus" />
-    <item
-        android:id="@+id/action_lookup_dictionary"
-        android:title="@string/menu_lookup_dictionary" />
+
+        <item
+            android:id="@+id/action_lookup_rhymer"
+            android:title="@string/menu_lookup_rhymer" />
+        <item
+            android:id="@+id/action_lookup_thesaurus"
+            android:title="@string/menu_lookup_thesaurus" />
+        <item
+            android:id="@+id/action_lookup_dictionary"
+            android:title="@string/menu_lookup_dictionary" />
 </menu>

--- a/app/src/main/res/menu/menu_word_other.xml
+++ b/app/src/main/res/menu/menu_word_other.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016-2017 Carmen Alvarez
+  ~ Copyright (c) 2017 Carmen Alvarez
   ~
   ~ This file is part of Poet Assistant.
   ~
@@ -17,13 +17,16 @@
   ~ along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<resources>
-    <item name="wrap_content" format="integer" type="dimen">-2</item>
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
-    <dimen name="list_rtd_icon_size">44dp</dimen>
-    <dimen name="list_rtd_icon_padding">4dp</dimen>
-    <dimen name="list_rt_item_heading_height">@dimen/wrap_content</dimen>
-    <dimen name="list_rt_item_subheading_height">@dimen/wrap_content</dimen>
-    <dimen name="seekbar_horizontal_padding_fix">0dp</dimen>
-</resources>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <group
+        android:id="@+id/group_system_popup_menu_items"
+        android:checkableBehavior="none">
+
+        <item
+            android:id="@+id/action_copy"
+            android:title="@string/menu_copy" />
+        <item
+            android:id="@+id/action_share"
+            android:title="@string/share" />
+    </group>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Carmen Alvarez
+  ~ Copyright (c) 2016-2017 Carmen Alvarez
   ~
   ~ This file is part of Poet Assistant.
   ~
@@ -98,6 +98,9 @@
     <string name="menu_lookup_rhymer">Rhymer</string>
     <string name="menu_lookup_thesaurus">Thesaurus</string>
     <string name="menu_lookup_dictionary">Dictionary</string>
+    <string name="menu_copy">Copy</string>
+    <string name="menu_more">More…</string>
+    <string name="snackbar_copied_text">Copied text to clipboard</string>
     <string name="title_activity_settings">Settings</string>
     <string name="wotd_setting_title">Word of the day</string>
     <string name="wotd_setting_description">Display a notification once a day with a random word.</string>
@@ -151,13 +154,25 @@
         <item>@string/pref_theme_value_dark</item>
         <item>@string/pref_theme_value_auto</item>
     </string-array>
-    <string name="pref_system_tts_settings_title">System voice settings</string>
-    <string name="pref_system_tts_settings_description">This will leave Poet Assistant and open the system text-to-speech settings on your device.</string>
     <string-array name="pref_theme_values">
         <item>Light</item>
         <item>Dark</item>
         <item>Auto</item>
     </string-array>
+    <string name="pref_layout_title">Layout</string>
+    <string name="pref_layout_summary">%s</string>
+    <string name="pref_layout_value_clean">Clean</string>
+    <string name="pref_layout_value_efficient">Efficient</string>
+    <string-array name="pref_layout_titles">
+        <item>@string/pref_layout_value_clean</item>
+        <item>@string/pref_layout_value_efficient</item>
+    </string-array>
+    <string-array name="pref_layout_values">
+        <item>Clean</item>
+        <item>Efficient</item>
+    </string-array>
+    <string name="pref_system_tts_settings_title">System voice settings</string>
+    <string name="pref_system_tts_settings_description">This will leave Poet Assistant and open the system text-to-speech settings on your device.</string>
     <string name="tts_error"><![CDATA[No voices found! &#128552;]]></string>
     <string name="tts_error_open_system_settings">Voice settings</string>
     <string name="tts_error_open_app_settings">Settings</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Carmen Alvarez
+  ~ Copyright (c) 2016-2017 Carmen Alvarez
   ~
   ~ This file is part of Poet Assistant.
   ~
@@ -28,6 +28,8 @@
         <item name="android:textColorPrimary">@color/primary_text</item>
         <item name="android:textColorSecondary">@color/secondary_text</item>
         <item name="alertDialogTheme">@style/AppAlertDialog</item>
+        <item name="windowActionModeOverlay">true</item>
+
     </style>
 
     <style name="AppTheme" parent="AppBaseTheme">

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2016 Carmen Alvarez
+  ~ Copyright (c) 2016-2017 Carmen Alvarez
   ~
   ~ This file is part of Poet Assistant.
   ~
@@ -77,6 +77,16 @@
             android:positiveButtonText="@null"
             android:summary="@string/pref_theme_summary"
             android:title="@string/pref_theme_title" />
+
+        <ListPreference
+            android:defaultValue="Efficient"
+            android:entries="@array/pref_layout_titles"
+            android:entryValues="@array/pref_layout_values"
+            android:key="PREF_LAYOUT"
+            android:negativeButtonText="@null"
+            android:positiveButtonText="@null"
+            android:summary="@string/pref_layout_summary"
+            android:title="@string/pref_layout_title" />
 
         <!--suppress AndroidElementNotAllowed -->
         <android.support.v7.preference.SwitchPreferenceCompat


### PR DESCRIPTION
* The "clean" layout has no RTD buttons: you tap on a word to see a popup with the RTD entries and other actions..
* The "efficient" layout: you have the RTD buttons, tapping on a word shows additional actions.
* For selectable text (dictionary + reader): the rtd actions are inserted into the system actionmode