### PR TITLE
Use jack instead of retrolambda (now with greendao):

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,6 @@
 
 apply plugin: 'org.greenrobot.greendao'
 apply plugin: 'com.android.application'
-apply plugin: 'me.tatarka.retrolambda'
-apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'com.github.ben-manes.versions'
 
 
@@ -46,6 +44,9 @@ android {
         // setting vectorDrawables.useSupportLibrary = true means pngs won't be generated at
         // build time: http://android-developers.blogspot.fr/2016/02/android-support-library-232.html
         vectorDrawables.useSupportLibrary = true
+        jackOptions {
+            enabled true
+        }
     }
     buildTypes {
         release {
@@ -103,9 +104,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
-        classpath 'me.tatarka:gradle-retrolambda:3.4.0'
         classpath 'org.greenrobot:greendao-gradle-plugin:3.2.1'
     }
 }
@@ -116,7 +115,7 @@ greendao {
 }
 
 dependencies {
-    apt 'org.jraf:prefs-compiler:1.1.1'
+    annotationProcessor 'org.jraf:prefs-compiler:1.1.1'
 
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.android.support:design:25.1.0'
@@ -129,11 +128,10 @@ dependencies {
     compile 'ca.rmen:porter-stemmer:1.0.0'
     compile 'org.jraf:prefs:1.1.1'
     compile 'com.google.dagger:dagger:2.8'
-    apt 'com.google.dagger:dagger-compiler:2.8'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.8'
 
     testCompile 'junit:junit:4.12'
 
-    retrolambdaConfig 'net.orfjackal.retrolambda:retrolambda:2.4.0'
 }
 
 // Only show real releases with the ben-manes plugin.

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta2'
 
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         configurations.classpath.exclude group: 'com.android.tools.external.lombok'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
This requires:
* gradle 3.3
* android gradle plugin 2.3.0-beta2
* annotationProcessor instead of apt

----

This doesn't work :( Compilation fails with:
```
:app:greendao FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:greendao'.
> org.eclipse.jdt.internal.compiler.impl.CompilerOptions.versionToJdkLevel(Ljava/lang/Object;)J

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```

https://github.com/greenrobot/greenDAO/issues/498