### PR TITLE
Issue #79: Experiment a workaround for a ClassCastException

### DIFF
--- a/app/src/main/java/ca/rmen/android/poetassistant/dagger/DaggerHelper.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/dagger/DaggerHelper.java
@@ -19,6 +19,7 @@
 
 package ca.rmen.android.poetassistant.dagger;
 
+import android.app.Application;
 import android.content.Context;
 
 import ca.rmen.android.poetassistant.PoetAssistantApplication;
@@ -28,12 +29,20 @@ public class DaggerHelper {
         return getAppComponent(context).getMainScreenComponent();
     }
 
+    public static AppComponent.MainScreenComponent getMainScreenComponent(Application application) {
+        return ((PoetAssistantApplication) application).getAppComponent().getMainScreenComponent();
+    }
+
     public static AppComponent.SettingsComponent getSettingsComponent(Context context) {
         return getAppComponent(context).getSettingsComponent();
     }
 
     public static AppComponent.WotdComponent getWotdComponent(Context context) {
         return getAppComponent(context).getWotdComponent();
+    }
+
+    public static AppComponent.WotdComponent getWotdComponent(Application application) {
+        return ((PoetAssistantApplication) application).getAppComponent().getWotdComponent();
     }
 
     private static AppComponent getAppComponent(Context context) {

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/search/Search.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/search/Search.java
@@ -64,7 +64,7 @@ public class Search {
     @Inject Dictionary mDictionary;
 
     public Search(Activity searchableActivity, ViewPager viewPager) {
-        DaggerHelper.getMainScreenComponent(searchableActivity).inject(this);
+        DaggerHelper.getMainScreenComponent(searchableActivity.getApplication()).inject(this);
         mContext = searchableActivity;
         mViewPager = viewPager;
         mPagerAdapter = (PagerAdapter) viewPager.getAdapter();

--- a/app/src/main/java/ca/rmen/android/poetassistant/wotd/WotdJobService.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/wotd/WotdJobService.java
@@ -40,7 +40,7 @@ public class WotdJobService extends JobService {
     @Override
     public void onCreate() {
         super.onCreate();
-        DaggerHelper.getWotdComponent(this).inject(this);
+        DaggerHelper.getWotdComponent(getApplication()).inject(this);
     }
 
     @Override


### PR DESCRIPTION
I haven't found out how to reproduce a crash where `getApplicationContext()` returns an `Application` object which is not a `PoetAssistantApplication` object.  Let's see if `getApplication()` has the same problem.