### PR TITLE
Fix for issue #81

### DIFF
--- a/app/src/main/java/ca/rmen/android/poetassistant/main/MainActivity.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/MainActivity.java
@@ -188,8 +188,8 @@ public class MainActivity extends AppCompatActivity implements OnWordClickListen
         if (uri == null) return;
         String word = uri.getLastPathSegment();
         if(Constants.DEEP_LINK_QUERY.equals(uri.getHost())) {
-            mSearch.search(word);
             mBinding.viewPager.setCurrentItem(mPagerAdapter.getPositionForTab(Tab.DICTIONARY), false);
+            mSearch.search(word);
         } else {
             Tab tab = Tab.parse(uri.getHost());
             if (tab != null) mSearch.search(word, tab);

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListHeaderFragment.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListHeaderFragment.java
@@ -80,6 +80,7 @@ public class ResultListHeaderFragment extends Fragment
     }
 
     public void setHeader(String header) {
+        Log.v(TAG, mTab + " setHeader " + header);
         mBinding.getViewModel().query.set(header);
     }
 

--- a/app/src/main/java/ca/rmen/android/poetassistant/widget/DebounceTextWatcher.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/widget/DebounceTextWatcher.java
@@ -29,9 +29,10 @@ import io.reactivex.ObservableEmitter;
 
 public final class DebounceTextWatcher {
     public static Observable<String> observe(TextView textView) {
-        return Observable.create((ObservableEmitter<String> emmiter) -> {
-            EmitterTextWatcher textWatcher = new EmitterTextWatcher(emmiter);
+        return Observable.create((ObservableEmitter<String> emitter) -> {
+            EmitterTextWatcher textWatcher = new EmitterTextWatcher(emitter);
             textView.addTextChangedListener(textWatcher);
+            emitter.setCancellable(() -> textView.removeTextChangedListener(textWatcher));
         }).debounce(5000, TimeUnit.MILLISECONDS);
     }
 

--- a/app/src/main/java/ca/rmen/android/poetassistant/widget/ViewShownCompletable.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/widget/ViewShownCompletable.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016-2017 Carmen Alvarez
+ *
+ * This file is part of Poet Assistant.
+ *
+ * Poet Assistant is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Poet Assistant is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ca.rmen.android.poetassistant.widget;
+
+import android.os.Build;
+import android.view.View;
+import android.view.ViewTreeObserver;
+
+import io.reactivex.Completable;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+
+public final class ViewShownCompletable {
+
+    private ViewShownCompletable() {
+        // prevent instantiation
+    }
+
+    // Issue #19: In a specific scenario, the fragments may not be "ready" yet (onCreateView() may not have been called).
+    // Wait until the ViewPager is laid out before invoking anything on the fragments.
+    // (We assume that the fragments are "ready" once the ViewPager is laid out.)
+    public static Completable create(View view) {
+        return Completable.create(completableEmitter -> {
+            if (view.isShown()) {
+                completableEmitter.onComplete();
+            } else {
+                ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
+                    @Override
+                    public void onGlobalLayout() {
+                        removeOnGlobalLayoutListener(view, this);
+                        view.post(completableEmitter::onComplete);
+                    }
+                };
+                view.getViewTreeObserver().addOnGlobalLayoutListener(onGlobalLayoutListener);
+                completableEmitter.setCancellable(() -> removeOnGlobalLayoutListener(view, onGlobalLayoutListener));
+            }
+        }).observeOn(AndroidSchedulers.mainThread());
+    }
+
+    private static void removeOnGlobalLayoutListener(View view, ViewTreeObserver.OnGlobalLayoutListener listener) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            view.getViewTreeObserver().removeOnGlobalLayoutListener(listener);
+        } else {
+            //noinspection deprecation
+            view.getViewTreeObserver().removeGlobalOnLayoutListener(listener);
+        }
+    }
+}


### PR DESCRIPTION
Yet another fix for issue #81 

* Added a new espresso test for the crash which wasn't fixed yet.
* Need to use `View.post()` with the `OnGlobalLayoutListener` to be sure all the fragments are loaded before we try to search inside them
* Rx'ified the `OnGlobalLayoutListener`

Unrelated:
* Spelling fix in `DebounceTextWatcher`
* Remove the textview listener when cleaning up the `DebounceTextWatcher`