### PR TITLE
Attempt to fix ClassCastException crashes.

### DIFF
--- a/app/src/main/java/ca/rmen/android/poetassistant/PoetAssistantApplication.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/PoetAssistantApplication.java
@@ -22,13 +22,9 @@ import android.app.Application;
 
 import com.squareup.leakcanary.LeakCanary;
 
-import ca.rmen.android.poetassistant.dagger.AppComponent;
-import ca.rmen.android.poetassistant.dagger.AppModule;
-import ca.rmen.android.poetassistant.dagger.DaggerAppComponent;
 import ca.rmen.android.poetassistant.settings.SettingsPrefs;
 
 public class PoetAssistantApplication extends Application {
-    private AppComponent mAppComponent;
     @Override
     public void onCreate() {
         super.onCreate();
@@ -41,12 +37,4 @@ public class PoetAssistantApplication extends Application {
         Theme.setThemeFromSettings(SettingsPrefs.get(this));
     }
 
-    public AppComponent getAppComponent() {
-        if (mAppComponent == null) {
-            mAppComponent = DaggerAppComponent.builder()
-                    .appModule(new AppModule(this))
-                    .build();
-        }
-        return mAppComponent;
-    }
 }

--- a/app/src/main/java/ca/rmen/android/poetassistant/dagger/DaggerHelper.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/dagger/DaggerHelper.java
@@ -22,19 +22,23 @@ package ca.rmen.android.poetassistant.dagger;
 import android.app.Application;
 import android.content.Context;
 
-import ca.rmen.android.poetassistant.PoetAssistantApplication;
-
 public class DaggerHelper {
+    private static AppComponent sAppComponent;
+
     public static AppComponent.MainScreenComponent getMainScreenComponent(Context context) {
         return getAppComponent(context).getMainScreenComponent();
     }
 
     public static AppComponent.MainScreenComponent getMainScreenComponent(Application application) {
-        return ((PoetAssistantApplication) application).getAppComponent().getMainScreenComponent();
+        return getAppComponent(application).getMainScreenComponent();
     }
 
     public static AppComponent.SettingsComponent getSettingsComponent(Context context) {
         return getAppComponent(context).getSettingsComponent();
+    }
+
+    public static AppComponent.SettingsComponent getSettingsComponent(Application application) {
+        return getAppComponent(application).getSettingsComponent();
     }
 
     public static AppComponent.WotdComponent getWotdComponent(Context context) {
@@ -42,11 +46,19 @@ public class DaggerHelper {
     }
 
     public static AppComponent.WotdComponent getWotdComponent(Application application) {
-        return ((PoetAssistantApplication) application).getAppComponent().getWotdComponent();
+        return getAppComponent(application).getWotdComponent();
     }
 
     private static AppComponent getAppComponent(Context context) {
-        return ((PoetAssistantApplication) context.getApplicationContext()).getAppComponent();
+        return getAppComponent((Application) context.getApplicationContext());
     }
 
+    private static AppComponent getAppComponent(Application application) {
+        if (sAppComponent == null) {
+            sAppComponent = DaggerAppComponent.builder()
+                    .appModule(new AppModule(application))
+                    .build();
+        }
+        return sAppComponent;
+    }
 }

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/MainActivity.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/MainActivity.java
@@ -135,7 +135,7 @@ public class MainActivity extends AppCompatActivity implements OnWordClickListen
 
     @WorkerThread
     private boolean loadDatabase() {
-        DaggerHelper.getMainScreenComponent(MainActivity.this).inject(MainActivity.this);
+        DaggerHelper.getMainScreenComponent(getApplication()).inject(MainActivity.this);
         return mRhymer.isLoaded() && mThesaurus.isLoaded() && mDictionary.isLoaded();
     }
 

--- a/app/src/main/java/ca/rmen/android/poetassistant/settings/SettingsActivity.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/settings/SettingsActivity.java
@@ -70,7 +70,7 @@ public class SettingsActivity extends AppCompatActivity implements ConfirmDialog
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        DaggerHelper.getSettingsComponent(this).inject(this);
+        DaggerHelper.getSettingsComponent(getApplication()).inject(this);
         mBinding = DataBindingUtil.setContentView(this, R.layout.activity_settings);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) actionBar.setDisplayHomeAsUpEnabled(true);


### PR DESCRIPTION
Example:
```
Caused by: java.lang.ClassCastException:
  at ca.rmen.android.poetassistant.main.dictionaries.search.Search.<init>(Search.java:1033)
  at ca.rmen.android.poetassistant.main.MainActivity.onCreate(MainActivity.java:116)
  at android.app.Activity.performCreate(Activity.java:6912)
  at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1126)
  at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2900)
```