### PR TITLE
Migrate some ObservableFields to LiveDatas.

### DIFF
--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListHeaderFragment.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListHeaderFragment.java
@@ -22,7 +22,6 @@ package ca.rmen.android.poetassistant.main.dictionaries;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
 import android.databinding.DataBindingUtil;
-import android.databinding.Observable;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
@@ -38,7 +37,6 @@ import java.util.Locale;
 import ca.rmen.android.poetassistant.Constants;
 import ca.rmen.android.poetassistant.R;
 import ca.rmen.android.poetassistant.Tts;
-import ca.rmen.android.poetassistant.databinding.BindingCallbackAdapter;
 import ca.rmen.android.poetassistant.databinding.ResultListHeaderBinding;
 import ca.rmen.android.poetassistant.main.Tab;
 
@@ -73,17 +71,11 @@ public class ResultListHeaderFragment extends Fragment
         mBinding.setButtonListener(new ButtonListener());
         mViewModel = ViewModelProviders.of(getParentFragment()).get(ResultListHeaderViewModel.class);
         mBinding.setViewModel(mViewModel);
-        mViewModel.snackbarText.addOnPropertyChangedCallback(mSnackbarTextChanged);
+        mViewModel.snackbarText.observe(this, mSnackbarTextChanged);
         mViewModel.isFavoriteLiveData.observe(this, mFavoriteObserver);
         mViewModel.ttsStateLiveData.observe(this, mTtsObserver);
 
         return mBinding.getRoot();
-    }
-
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView();
-        mViewModel.snackbarText.removeOnPropertyChangedCallback(mSnackbarTextChanged);
     }
 
     @Override
@@ -99,13 +91,11 @@ public class ResultListHeaderFragment extends Fragment
         }
     }
 
-    private final Observable.OnPropertyChangedCallback mSnackbarTextChanged =
-            new BindingCallbackAdapter(() -> {
-                String text = mViewModel.snackbarText.get();
-                if (!TextUtils.isEmpty(text)) {
-                    Snackbar.make(mBinding.getRoot(), text, Snackbar.LENGTH_SHORT).show();
-                }
-            });
+    private final Observer<String> mSnackbarTextChanged = text -> {
+        if (!TextUtils.isEmpty(text)) {
+            Snackbar.make(mBinding.getRoot(), text, Snackbar.LENGTH_SHORT).show();
+        }
+    };
 
     private final Observer<Boolean> mFavoriteObserver = isFavorite -> mBinding.btnStarQuery.setChecked(isFavorite == Boolean.TRUE);
     private final Observer<Tts.TtsState> mTtsObserver = ttsState -> {

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListHeaderViewModel.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListHeaderViewModel.java
@@ -22,6 +22,7 @@ package ca.rmen.android.poetassistant.main.dictionaries;
 import android.app.Application;
 import android.arch.lifecycle.AndroidViewModel;
 import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
 import android.arch.lifecycle.Transformations;
 import android.databinding.ObservableBoolean;
 import android.databinding.ObservableField;
@@ -41,8 +42,8 @@ public class ResultListHeaderViewModel extends AndroidViewModel {
     public final ObservableField<String> filter = new ObservableField<>();
     public final ObservableBoolean isFavorite = new ObservableBoolean();
     public final ObservableBoolean showHeader = new ObservableBoolean();
-    final ObservableField<String> snackbarText = new ObservableField<>();
 
+    final MutableLiveData<String> snackbarText = new MutableLiveData<>();
     final LiveData<Boolean> isFavoriteLiveData;
     final LiveData<Tts.TtsState> ttsStateLiveData;
 
@@ -79,7 +80,7 @@ public class ResultListHeaderViewModel extends AndroidViewModel {
 
     void clearFavorites () {
         mFavorites.clear();
-        snackbarText.set(getApplication().getString(R.string.favorites_cleared));
+        snackbarText.setValue(getApplication().getString(R.string.favorites_cleared));
     }
 
     @Override

--- a/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListViewModel.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/main/dictionaries/ResultListViewModel.java
@@ -51,10 +51,10 @@ public class ResultListViewModel<T> extends AndroidViewModel {
     private static final String TAG = Constants.TAG + ResultListViewModel.class.getSimpleName();
 
     public final ObservableBoolean isDataAvailable = new ObservableBoolean();
-    public final ObservableField<Settings.Layout> layout = new ObservableField<>();
     public final ObservableField<CharSequence> emptyText = new ObservableField<>();
-    final ObservableBoolean showHeader = new ObservableBoolean();
-    final ObservableField<String> usedQueryWord = new ObservableField<>();
+    final MutableLiveData<Settings.Layout> layout = new MutableLiveData<>();
+    final MutableLiveData<Boolean> showHeader = new MutableLiveData<>();
+    final MutableLiveData<String> usedQueryWord = new MutableLiveData<>();
     private ResultListAdapter<T> mAdapter;
     private Tab mTab;
     @Inject
@@ -123,9 +123,9 @@ public class ResultListViewModel<T> extends AndroidViewModel {
         } else {
             emptyText.set(null);
         }
-        showHeader.set(hasQuery);
+        showHeader.setValue(hasQuery);
         if (loadedData != null) {
-            usedQueryWord.set(loadedData.matchedWord);
+            usedQueryWord.setValue(loadedData.matchedWord);
         }
         updateDataAvailable();
     }
@@ -154,8 +154,7 @@ public class ResultListViewModel<T> extends AndroidViewModel {
 
     private final SharedPreferences.OnSharedPreferenceChangeListener mPrefsListener = (sharedPreferences, key) -> {
         if (Settings.PREF_LAYOUT.equals(key)) {
-            layout.set(Settings.getLayout(SettingsPrefs.get(getApplication())));
+            layout.setValue(Settings.getLayout(SettingsPrefs.get(getApplication())));
         }
     };
-
 }

--- a/app/src/main/java/ca/rmen/android/poetassistant/settings/SettingsActivity.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/settings/SettingsActivity.java
@@ -24,7 +24,6 @@ import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.databinding.DataBindingUtil;
-import android.databinding.Observable;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Build;
@@ -35,6 +34,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceCategory;
 import android.support.v7.preference.PreferenceFragmentCompat;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 
@@ -44,7 +44,6 @@ import ca.rmen.android.poetassistant.Constants;
 import ca.rmen.android.poetassistant.R;
 import ca.rmen.android.poetassistant.Tts;
 import ca.rmen.android.poetassistant.dagger.DaggerHelper;
-import ca.rmen.android.poetassistant.databinding.BindingCallbackAdapter;
 import ca.rmen.android.poetassistant.main.dictionaries.ConfirmDialogFragment;
 
 public class SettingsActivity extends AppCompatActivity {
@@ -86,6 +85,7 @@ public class SettingsActivity extends AppCompatActivity {
             DaggerHelper.getSettingsComponent(getContext()).inject(this);
             mViewModel = ViewModelProviders.of(this).get(SettingsViewModel.class);
             mTts.getTtsLiveData().observe(this, mTtsObserver);
+            mViewModel.snackbarText.observe(this, mSnackbarCallback);
         }
 
         @Override
@@ -141,12 +141,10 @@ public class SettingsActivity extends AppCompatActivity {
                 mTts.restart();
                 mRestartTtsOnResume = false;
             }
-            mViewModel.snackbarText.addOnPropertyChangedCallback(mSnackbarCallback);
         }
 
         @Override
         public void onPause() {
-            mViewModel.snackbarText.removeOnPropertyChangedCallback(mSnackbarCallback);
             mTts.stop();
             super.onPause();
         }
@@ -206,12 +204,12 @@ public class SettingsActivity extends AppCompatActivity {
             });
         }
 
-        private final Observable.OnPropertyChangedCallback mSnackbarCallback = new BindingCallbackAdapter(() -> {
+        private final Observer<String> mSnackbarCallback = snackbarText -> {
             View rootView = getView();
-            if (rootView != null) {
-                Snackbar.make(rootView, mViewModel.snackbarText.get(), Snackbar.LENGTH_LONG).show();
+            if (rootView != null && !TextUtils.isEmpty(snackbarText)) {
+                Snackbar.make(rootView, snackbarText, Snackbar.LENGTH_LONG).show();
             }
-        });
+        };
 
         private final Observer<Tts.TtsState> mTtsObserver = ttsState -> {
             Log.v(TAG, "ttsState = " + ttsState);

--- a/app/src/main/java/ca/rmen/android/poetassistant/settings/SettingsViewModel.java
+++ b/app/src/main/java/ca/rmen/android/poetassistant/settings/SettingsViewModel.java
@@ -22,8 +22,8 @@ package ca.rmen.android.poetassistant.settings;
 import android.annotation.TargetApi;
 import android.app.Application;
 import android.arch.lifecycle.AndroidViewModel;
+import android.arch.lifecycle.MutableLiveData;
 import android.content.Intent;
-import android.databinding.ObservableField;
 import android.net.Uri;
 import android.os.Build;
 import android.support.v7.preference.PreferenceManager;
@@ -47,7 +47,7 @@ public class SettingsViewModel extends AndroidViewModel {
     @Inject
     Tts mTts;
 
-    final ObservableField<String> snackbarText = new ObservableField<>();
+    final MutableLiveData<String> snackbarText = new MutableLiveData<>();
     private final SettingsChangeListener mListener;
 
     public SettingsViewModel(Application application) {
@@ -84,8 +84,8 @@ public class SettingsViewModel extends AndroidViewModel {
         Completable.fromAction(() -> mFavorites.exportFavorites(getApplication(), uri))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(() -> snackbarText.set(getApplication().getString(R.string.export_favorites_success, fileDisplayName)),
-                        throwable -> snackbarText.set(getApplication().getString(R.string.export_favorites_error, fileDisplayName)));
+                .subscribe(() -> snackbarText.setValue(getApplication().getString(R.string.export_favorites_success, fileDisplayName)),
+                        throwable -> snackbarText.setValue(getApplication().getString(R.string.export_favorites_error, fileDisplayName)));
 
     }
 
@@ -94,8 +94,8 @@ public class SettingsViewModel extends AndroidViewModel {
         Completable.fromAction(() -> mFavorites.importFavorites(getApplication(), uri))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(() -> snackbarText.set(getApplication().getString(R.string.import_favorites_success, fileDisplayName)),
-                        throwable -> snackbarText.set(getApplication().getString(R.string.import_favorites_error, fileDisplayName)));
+                .subscribe(() -> snackbarText.setValue(getApplication().getString(R.string.import_favorites_success, fileDisplayName)),
+                        throwable -> snackbarText.setValue(getApplication().getString(R.string.import_favorites_error, fileDisplayName)));
 
     }
 
@@ -103,7 +103,7 @@ public class SettingsViewModel extends AndroidViewModel {
         Completable.fromRunnable(() -> getApplication().getContentResolver().delete(SuggestionsProvider.CONTENT_URI, null, null))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(() -> snackbarText.set(getApplication().getString(R.string.search_history_cleared)));
+                .subscribe(() -> snackbarText.setValue(getApplication().getString(R.string.search_history_cleared)));
     }
 
     @Override


### PR DESCRIPTION
When to use ObservableFields:
* when they are referenced from xml for databinding

When to use LiveData:
* all other cases (of notifying the activity/fragment to update the ui).

I prefer LiveData over ObservableField when possible because:
* LiveData observers will only be triggered when the activity is resumed
* The observers can directly be lambdas: no need for the `BindingCallbackAdapter` workaround.
* Don't need to explicitly unregister the observers in `onDestroy()`