### PR TITLE
Issue 144: Use coroutines instead of Handlers.

### DIFF
--- a/app/src/androidTest/kotlin/ca/rmen/android/poetassistant/InstrumentationThreading.kt
+++ b/app/src/androidTest/kotlin/ca/rmen/android/poetassistant/InstrumentationThreading.kt
@@ -41,9 +41,9 @@ class InstrumentationThreading : CoroutineThreading(CommonPool, UI) {
 
     fun getCountingIdlingResource() = mCountingIdlingResource
 
-    override fun executeForeground(body: () -> Unit) {
+    override fun executeForeground(delayMs: Long, body: () -> Unit) : Threading.Cancelable {
         mCountingIdlingResource.increment()
-        super.executeForeground(decorateForegroundTask(body))
+        return super.executeForeground(delayMs, decorateForegroundTask(body))
     }
 
     override fun <T> execute(backgroundTask: () -> T, foregroundTask: ((T) -> Unit)?, errorTask: ((Throwable) -> Unit)?) {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/Threading.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/Threading.kt
@@ -21,10 +21,14 @@ package ca.rmen.android.poetassistant
 
 interface Threading {
 
+    interface Cancelable {
+        fun cancel()
+    }
+
     /**
      * Run the given task on the ui thread
      */
-    fun executeForeground(body: () -> Unit)
+    fun executeForeground(delayMs: Long = 0, body: () -> Unit) : Cancelable
 
     /**
      * Run the given background task on a background thread. If a foreground task is specified, it will be

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/reader/ReaderViewModel.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/reader/ReaderViewModel.kt
@@ -44,7 +44,6 @@ import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.Tts
 import ca.rmen.android.poetassistant.TtsState
 import ca.rmen.android.poetassistant.dagger.DaggerHelper
-import ca.rmen.android.poetassistant.databinding.BindingCallbackAdapter
 import ca.rmen.android.poetassistant.databinding.LiveDataMapping
 import ca.rmen.android.poetassistant.main.dictionaries.Share
 import javax.inject.Inject
@@ -111,12 +110,10 @@ class ReaderViewModel(application: Application) : AndroidViewModel(application) 
                 { ttsState -> playButtonStateLiveData.value = toPlayButtonState(ttsState, poem.get()) })
         playButtonStateLiveData.addSource(LiveDataMapping.fromObservableField(poem),
                 { poemText -> playButtonStateLiveData.value = toPlayButtonState(mTts.getTtsState(), poemText) })
-        poem.addOnPropertyChangedCallback(BindingCallbackAdapter(callback = object : BindingCallbackAdapter.Callback {
-            override fun onChanged() {
-                wordCountText.set(WordCounter.getWordCountText(application, poem.get()))
-            }
+    }
 
-        }))
+    fun updateWordCount() {
+        wordCountText.set(WordCounter.getWordCountText(getApplication(), poem.get()))
     }
 
     // begin TTS

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/widget/DebounceTextWatcher.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/widget/DebounceTextWatcher.kt
@@ -19,26 +19,28 @@
 
 package ca.rmen.android.poetassistant.widget
 
-import android.os.Handler
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.TextView
+import ca.rmen.android.poetassistant.Threading
+import ca.rmen.android.poetassistant.dagger.DaggerHelper
 
 object DebounceTextWatcher {
+
     fun debounce(textView: TextView, body: () -> Unit) {
-        val handler = Handler()
+        var cancelable : Threading.Cancelable? = null
+        val threading = DaggerHelper.getMainScreenComponent(textView.context).getThreading()
         textView.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
             }
 
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-                handler.removeCallbacksAndMessages(null)
-                handler.postDelayed(body, 5000)
+                cancelable?.cancel()
+                cancelable = threading.executeForeground(500, body)
             }
 
             override fun afterTextChanged(p0: Editable?) {
             }
-
         })
     }
 }

--- a/app/src/test/kotlin/ca/rmen/android/poetassistant/JunitThreading.kt
+++ b/app/src/test/kotlin/ca/rmen/android/poetassistant/JunitThreading.kt
@@ -23,8 +23,9 @@ package ca.rmen.android.poetassistant
  * Run background and foreground tasks directly in the same thread, blocking.
  */
 class JunitThreading : Threading {
-    override fun executeForeground(body: () -> Unit) {
+    override fun executeForeground(delayMs: Long, body: () -> Unit) : Threading.Cancelable {
         body.invoke()
+        return NoOpCancelable()
     }
 
     override fun <T> execute(backgroundTask: () -> T, foregroundTask: ((T) -> Unit)?, errorTask: ((Throwable) -> Unit)?) {
@@ -33,6 +34,11 @@ class JunitThreading : Threading {
             foregroundTask?.invoke(result)
         } catch (t: Throwable) {
             errorTask?.invoke(t)
+        }
+    }
+
+    private class NoOpCancelable : Threading.Cancelable {
+        override fun cancel() {
         }
     }
 }


### PR DESCRIPTION
Handlers were used in two places to post a `Runnable` with a delay, on the main thread.

Replace this with the `delay()` function of Kotlin coroutines, and encapsulate this in the `Threading` interface.