### PR TITLE
Update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ android {
         enabled = true
     }
     jacoco {
-        version "0.8.3"
+        version "0.8.4"
     }
     lintOptions {
         abortOnError true
@@ -138,7 +138,7 @@ android {
 }
 
 jacoco {
-    toolVersion '0.8.3'
+    toolVersion '0.8.4'
 }
 android.applicationVariants.all { variant ->
     variant.mergeAssets.doLast {
@@ -170,7 +170,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.22.0'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.6'
     }
 }
@@ -228,7 +228,7 @@ dependencies {
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->
         rules.all { ComponentSelection selection ->
-            boolean rejected = ['alpha', 'alpha-preview', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
+            boolean rejected = ['alpha', 'alpha-preview', 'beta', 'rc', 'cr', 'm', 'eap'].any { qualifier ->
                 selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
             }
             if ("com.android.databinding" == selection.candidate.group) {
@@ -283,6 +283,3 @@ kapt {
     }
 }
 
-android.packagingOptions {
-    pickFirst "META-INF/atomicfu.kotlin_module"
-}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,8 +49,8 @@ android {
         applicationId "ca.rmen.android.poetassistant"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 112902
-        versionName "1.29.2"
+        versionCode 113000
+        versionName "1.30.0"
         // setting vectorDrawables.useSupportLibrary = true means pngs won't be generated at
         // build time: http://android-developers.blogspot.fr/2016/02/android-support-library-232.html
         vectorDrawables.useSupportLibrary = true

--- a/app/src/test/java/ca/rmen/android/poetassistant/main/settings/SettingsActivityTest.java
+++ b/app/src/test/java/ca/rmen/android/poetassistant/main/settings/SettingsActivityTest.java
@@ -23,21 +23,22 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.ResolveInfo;
-import androidx.preference.Preference;
-import androidx.preference.PreferenceCategory;
-import androidx.preference.PreferenceFragmentCompat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowPackageManager;
 
+import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceFragmentCompat;
 import ca.rmen.android.poetassistant.Environment;
 import ca.rmen.android.poetassistant.R;
-import ca.rmen.android.poetassistant.settings.SettingsPrefs;
 import ca.rmen.android.poetassistant.settings.SettingsActivity;
+import ca.rmen.android.poetassistant.settings.SettingsPrefs;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -47,6 +48,7 @@ import static org.robolectric.Shadows.shadowOf;
 public class SettingsActivityTest {
     private static final String SYSTEM_TTS_SETTINGS_INTENT = "com.android.settings.TTS_SETTINGS";
     @Test
+    @Config(sdk=27)
     public void testSystemSettings() {
         mockSystemSettingsApp();
         ActivityController<SettingsActivity> activityController = Robolectric.buildActivity(SettingsActivity.class);

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.gradle_plugin_version = '3.4.0'
+    ext.gradle_plugin_version = '3.4.2'
     ext.kotlin_version = '1.3.30'
     ext.kotlin_coroutines_version = '1.2.0' // when we upgrade this, see if we can remove the packagingOptions hack https://github.com/Kotlin/kotlinx.coroutines/pull/1120
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,30 +21,30 @@
 
 buildscript {
     ext.gradle_plugin_version = '3.4.2'
-    ext.kotlin_version = '1.3.30'
-    ext.kotlin_coroutines_version = '1.2.0' // when we upgrade this, see if we can remove the packagingOptions hack https://github.com/Kotlin/kotlinx.coroutines/pull/1120
+    ext.kotlin_version = '1.3.41'
+    ext.kotlin_coroutines_version = '1.2.2'
 
     ext.appcompat_version = "1.0.2"
-    ext.collection_version = "1.0.0"
+    ext.collection_version = "1.1.0"
     ext.constraintlayout_version = "1.1.3"
     ext.lifecycle_version = "2.0.0"
     ext.material_version = "1.0.0"
     ext.preference_version = "1.0.0"
-    ext.room_version = "2.0.0"
+    ext.room_version = "2.1.0"
 
-    ext.dagger_version = '2.22.1'
+    ext.dagger_version = '2.24'
     ext.leak_canary_version = '1.6.3'
     ext.porterstemmer_version = "1.0.0"
     ext.rhymer_version = "1.2.0"
 
     ext.junit_version = "4.12"
-    ext.robolectric_version = "4.2.1"
+    ext.robolectric_version = "4.3"
     ext.festreflect_version = "1.4.1"
-    ext.androidx_test_runner_version = "1.1.1"
-    ext.androidx_test_rules_version = "1.1.1"
-    ext.androidx_test_core_version = "1.1.0"
-    ext.androidx_junit_version = "1.1.0"
-    ext.espresso_version = "3.1.1"
+    ext.androidx_test_runner_version = "1.2.0"
+    ext.androidx_test_rules_version = "1.2.0"
+    ext.androidx_test_core_version = "1.2.0"
+    ext.androidx_junit_version = "1.1.1"
+    ext.espresso_version = "3.2.0"
 
     repositories {
         google()
@@ -55,7 +55,7 @@ buildscript {
 
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         configurations.classpath.exclude group: 'com.android.tools.external.lombok'
-        classpath 'org.jacoco:org.jacoco.core:0.8.3'
+        classpath 'org.jacoco:org.jacoco.core:0.8.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Update agp: 3.4.0 -> 3.4.2

Update libraries:

    tools:
    ben-manes: 0.21.0 -> 0.22.0

    app:
    kotlin: 1.3.30 -> 1.3.41
    kotlin coroutines: 1.2.0 +> 1.2.2
    room: 2.0.0 -> 2.1.0
    dqgger: 2.22.1 -> 2.24

    tests:
    jacoco: 0.8.3 -> 0.8.4
    roboctric: 4.2.1 -> 4.3
    androidx test runner/rules: 1.1.1 -> 1.2.0
    androidx test core: 1.1.0 -> 1.2.0
    androidx junit: 1.1.0 -> 1.1.1
    espresso: 3.1.1 -> 3.2.0

Update gradle: 5.4 -> 5.5.1

Workaround a failing test by forcing sdk 27: If we use sdk 28 (or don't specify any sdk), 'SettingsActivityTest.testSystemSettings()' fails with the below exception. It passes on sdk 27. Will investigate the root cause later.
