### PR TITLE
Fix memory leak.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,7 +115,8 @@ android {
     }
 
     testOptions {
-        execution 'ANDROIDX_TEST_ORCHESTRATOR'
+        // Uncomment below to use orchestrator for tests
+        // execution 'ANDROIDX_TEST_ORCHESTRATOR'
         unitTests {
             all {
                 jvmArgs '-noverify', '-ea'

--- a/app/src/androidTest/java/ca/rmen/android/poetassistant/main/rules/ActivityTestRules.java
+++ b/app/src/androidTest/java/ca/rmen/android/poetassistant/main/rules/ActivityTestRules.java
@@ -75,6 +75,10 @@ final class ActivityTestRules {
         for (IdlingResource idlingResource : idlingResourceList) {
             IdlingRegistry.getInstance().unregister(idlingResource);
         }
+        TestAppComponent testAppComponent = (TestAppComponent) DaggerHelper.INSTANCE.getAppComponent(targetContext.getApplicationContext());
+        getInstrumentation().runOnMainSync(() ->  {
+            testAppComponent.getTts().shutdown();
+        });
     }
 
     private static void cleanup(Context targetContext) {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/Tts.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/Tts.kt
@@ -125,7 +125,7 @@ class Tts(private val context: Context, private val settingsPrefs: SettingsPrefs
         mTextToSpeech?.stop()
     }
 
-    private fun shutdown() {
+    fun shutdown() {
         mTextToSpeech?.let {
             it.setOnUtteranceProgressListener(null)
             @Suppress("DEPRECATION")
@@ -135,6 +135,7 @@ class Tts(private val context: Context, private val settingsPrefs: SettingsPrefs
             threading.executeForeground { mTtsLiveData.value = TtsState(TtsState.TtsStatus.INITIALIZED, TtsState.TtsStatus.UNINITIALIZED, null) }
             mTextToSpeech = null
         }
+        PreferenceManager.getDefaultSharedPreferences(context).unregisterOnSharedPreferenceChangeListener(mTtsPrefsListener)
     }
 
     private fun useVoiceFromSettings() = useVoice(mTextToSpeech, settingsPrefs.voice)


### PR DESCRIPTION
* Call `Tts.shutdown()` in test cleanup.
* Make `Tts.shutdown()` unregister its shared preference listener.
* Disable orchestrator, as we don't need it now.