### PR TITLE
Fix process-text intent filter.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -98,15 +98,28 @@
         </activity>
         <activity android:name=".main.dictionaries.search.RhymerRouterActivity"
             android:theme="@android:style/Theme.NoDisplay"
+            android:label="@string/tab_rhymer"
             android:exported="true">
             <intent-filter android:icon="@drawable/ic_rhymer" android:label="@string/tab_rhymer">
                 <action android:name="android.intent.action.PROCESS_TEXT"/>
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <!--
+                Add this intent-filter as a workaround to make the PROCESS_TEXT
+                intent-filter work in Google apps (ex: chrome, keep, ...).
+                https://stackoverflow.com/a/72930519/1204440
+                Note: we only need to add it to one of the three activities, and
+                this will make PROCESS_TEXT work in all three.
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="https" />
+            </intent-filter>
         </activity>
         <activity android:name=".main.dictionaries.search.ThesaurusRouterActivity"
             android:theme="@android:style/Theme.NoDisplay"
+            android:label="@string/tab_thesaurus"
             android:exported="true">
             <intent-filter android:icon="@drawable/ic_thesaurus" android:label="@string/tab_thesaurus">
                 <action android:name="android.intent.action.PROCESS_TEXT"/>
@@ -116,6 +129,7 @@
         </activity>
         <activity android:name=".main.dictionaries.search.DictionaryRouterActivity"
             android:theme="@android:style/Theme.NoDisplay"
+            android:label="@string/tab_dictionary"
             android:exported="true">
             <intent-filter android:icon="@drawable/ic_dictionary" android:label="@string/tab_dictionary">
                 <action android:name="android.intent.action.PROCESS_TEXT"/>


### PR DESCRIPTION
Issue #190:

Poet assistant stops appearing in the text selection menu in some Google apps (chrome, keep, ...), starting in Android 14.

This weird change, to add the `<intent-filter>` for the `VIEW` action and the `https` data schema, seems to make this work again.

Also: add the `android:label` to the `<activity>` elements to make the proper labels appear in some apps which were just showing "Poet Assistant" (ex: Firefox).