### PR TITLE
Fix code coverage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -19,16 +20,29 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
       - name: Run unit tests
-        run: ./gradlew --no-daemon testDebugUnitTest
+        run: ./gradlew --no-daemon testDebugUnitTest jacocoTestReport
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
         if: always() # always run even if the previous step fails
         with:
           report_paths: "app/build/test-results/testDebugUnitTest/*.xml"
           check_name: UnitTests
-      - name: Archive reports
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: |
+            ${{ github.workspace }}/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Archive unit tests
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: reports
+          name: unit-tests
           path: app/build/reports/tests/testDebugUnitTest
+      - name: Archive coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: app/build/reports/jacoco

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -299,6 +299,9 @@ task jacocoTestReport(type: JacocoReport) {
                     "outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec",
                     "outputs/code_coverage/debugAndroidTest/connected/**/*.ec"
             ]))
+    reports {
+        xml.required = true
+    }
 }
 
 // Necessary for Prefs to work (see https://kotlinlang.org/docs/reference/kapt.html)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ android {
         buildConfig = true
     }
     jacoco {
-        version "0.8.8"
+        version "0.8.12"
     }
     lintOptions {
         abortOnError true
@@ -74,7 +74,7 @@ android {
         // "pm clear" command after each test invocation. This command ensures
         // that the app's state is completely cleared between tests.
         // https://developer.android.com/training/testing/instrumented-tests/androidx-test-libraries/runner#use-android
-        testInstrumentationRunnerArguments clearPackageData: 'true', coverage: 'true', coverageFilePath: '/data/data/ca.rmen.android.poetassistant.test/'
+        // testInstrumentationRunnerArguments clearPackageData: 'true', coverage: 'true', coverageFilePath: '/data/data/ca.rmen.android.poetassistant.test/'
 
 
         // used by Room, to test migrations
@@ -168,7 +168,7 @@ android {
 }
 
 jacoco {
-    toolVersion '0.8.8'
+    toolVersion '0.8.12'
 }
 android.applicationVariants.all { variant ->
     variant.getMergeAssetsProvider().get().doLast {
@@ -270,6 +270,7 @@ dependencyUpdates.resolutionStrategy {
 }
 task jacocoTestReport(type: JacocoReport) {
     mustRunAfter "testDebugUnitTest"
+    mustRunAfter "connectedDebugAndroidTest"
     mustRunAfter "createDebugCoverageReport"
     getClassDirectories().setFrom(fileTree(
             dir: "${buildDir}",

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ buildscript {
 
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         configurations.classpath.exclude group: 'com.android.tools.external.lombok'
-        classpath 'org.jacoco:org.jacoco.core:0.8.8'
+        classpath 'org.jacoco:org.jacoco.core:0.8.12'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
* Fix code coverage   
  * Update jacoco: 0.8.8 -> 0.8.12.
  * Add `mustRunAfter "connectedDebugAndroidTest"` to `jacocoTestReport` to avoid a gradle error when we run `jacocoTestReport`.
  * Comment-out config we added earlier for test orchestrator: it seems its `coverageFilePath`, pointing to a folder, was causing the `*.ec` coverage file for instrumented tests to not be generated.
* Add code coverage to PR workflow.