### PR TITLE
Add script to run tests using gmsaas.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,8 +5,10 @@ on:
       branches:
         - master
 jobs:
-  UnitTests:
+  Tests:
     runs-on: ubuntu-latest
+    env:
+      ANDROID_SDK_ROOT: ${{vars.ANDROID_SDK_ROOT}}
     permissions:
       checks: write
       pull-requests: write
@@ -17,16 +19,29 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-      - name: Run unit tests
-        run: ./gradlew --no-daemon testDebugUnitTest jacocoTestReport
-      - name: Publish Test Report
+      - name: Run tests
+        env:
+          GMSAAS_API_TOKEN: ${{secrets.GMSAAS_API_TOKEN}}
+          GMSAAS_RECIPE_UUID: ${{vars.GMSAAS_RECIPE_UUID}}
+        run: bash scripts/run_tests.bash
+      - name: Publish Unit Test Report
         uses: mikepenz/action-junit-report@v4
         if: always() # always run even if the previous step fails
         with:
           report_paths: "app/build/test-results/testDebugUnitTest/*.xml"
           check_name: UnitTests
+      - name: Publish Instrumentation Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: "app/build/outputs/androidTest-results/connected/**/*.xml"
+          check_name: InstrumentationTests
       - name: Add coverage to PR
         id: jacoco
         uses: madrapps/jacoco-report@v1.6.1
@@ -40,9 +55,21 @@ jobs:
         with:
           name: unit-tests
           path: app/build/reports/tests/testDebugUnitTest
+      - name: Archive instrumentation tests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumentation-tests
+          path: app/build/reports/androidTests/connected/debug
       - name: Archive coverage
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: app/build/reports/jacoco
+      - name: Archive logcat
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logcat
+          path: /tmp/lolcat.log

--- a/scripts/gmsaas-run-tests.py
+++ b/scripts/gmsaas-run-tests.py
@@ -1,0 +1,130 @@
+import argparse
+import json
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger("RUN-TESTS")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+)
+parser = argparse.ArgumentParser()
+parser.add_argument("recipe_uuid", type=str)
+args = parser.parse_args()
+recipe_uuid = args.recipe_uuid
+
+
+def run_gmsaas_command(command: str) -> dict:
+    return json.loads(
+        subprocess.check_output(
+            f"gmsaas --format json {command}",
+            shell=True,
+        )
+    )
+
+
+def gmsaas_stop_all_instances():
+    logger.info("Stop all instances.")
+    instances_list_output = run_gmsaas_command("instances list")
+
+    for instance in instances_list_output["instances"]:
+        run_gmsaas_command(f"instances stop {instance["uuid"]}")
+        logger.info(f"Stopped {instance["uuid"]} ({instance["name"]})")
+
+
+def gmsaas_authenticate():
+    logger.info("Authenticate.")
+    auth_token_output = run_gmsaas_command(
+        f"auth token {os.environ.get("GMSAAS_API_TOKEN")}"
+    )
+    logger.info(
+        f"Saved authentication to {auth_token_output["auth"]["authentication_path"]}"
+    )
+
+
+def gmsaas_logout():
+    logger.info("Logout")
+    run_gmsaas_command("auth reset")
+
+
+def gmsaas_config():
+    logger.info("Configure android sdk")
+    config_set_output = run_gmsaas_command(
+        f"config set android-sdk-path {os.environ.get("ANDROID_SDK_ROOT")}"
+    )
+    logger.info(f"Configuration now {config_set_output["configuration"]}")
+
+
+def gmsaas_start_instance() -> str:
+    logger.info("Start new instance.")
+    instances_start_output = run_gmsaas_command(
+        f"instances start {recipe_uuid} poet-assistant-tests"
+    )
+    instance_uuid = instances_start_output["instance"]["uuid"]
+    logger.info(f"Started instance {instance_uuid}.")
+    return instance_uuid
+
+
+def gmsaas_connect_adb(instance_uuid: str):
+    logger.info("Connect to adb.")
+    instances_adbconnect_output = run_gmsaas_command(
+        f"instances adbconnect {instance_uuid}"
+    )
+
+    adb_serial = instances_adbconnect_output["instance"]["adb_serial"]
+    logger.info(f"Adb serial: {adb_serial}")
+
+
+def adb_start_logcat():
+    logger.info("Start logcat.")
+    subprocess.Popen(
+        ["adb", "lolcat", "-v", "threadtime"],
+        stdout=open("/tmp/lolcat.log", "w"),
+        stderr=subprocess.STDOUT,
+    )
+
+
+def adb_disable_animations():
+    logger.info("Disable animations")
+    for animation_type in ["window", "transition", "animator"]:
+        subprocess.run(
+            f"adb shell settings put global {animation_type}_animation_scale 0".split(
+                " "
+            ),
+        )
+
+
+def gradle_run_tests() -> int:
+    logger.info("Run tests.")
+    test_process = subprocess.Popen(
+        ["./gradlew", "--no-daemon", "testDebugUnitTest", "cAT", "jacocoTestReport"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    for line in test_process.stdout:
+        logger.info(
+            line.rstrip()
+        )  # remove trailing newlines to avoid duplicate newlines.
+
+    test_process.wait()
+    return test_process.returncode
+
+
+# Setup the device.
+gmsaas_authenticate()
+gmsaas_config()
+gmsaas_stop_all_instances()
+instance_uuid = gmsaas_start_instance()
+gmsaas_connect_adb(instance_uuid)
+
+# Run the tests.
+adb_start_logcat()
+adb_disable_animations()
+tests_return_code = gradle_run_tests()
+
+# Cleanup.
+gmsaas_stop_all_instances()
+gmsaas_logout()
+
+exit(code=tests_return_code)

--- a/scripts/prepare_tests.bash
+++ b/scripts/prepare_tests.bash
@@ -1,4 +1,0 @@
-adb shell pm grant ca.rmen.android.poetassistant.test android.permission.POST_NOTIFICATIONS
-adb shell settings put global window_animation_scale 0
-adb shell settings put global transition_animation_scale 0
-adb shell settings put global animator_duration_scale 0

--- a/scripts/run_tests.bash
+++ b/scripts/run_tests.bash
@@ -1,0 +1,2 @@
+pip install gmsaas==1.12.0
+python ./scripts/gmsaas-run-tests.py ${GMSAAS_RECIPE_UUID}


### PR DESCRIPTION
Run it from the github tests action.

The script starts a Genymotion SaaS device. It runs instrumentation tests on this device. It also runs unit tests.
    
Archive both unit tests and instrumentation tests, as separate checks and reports.
The code coverage report is now unified, containing coverage from both unit and instrumentation tests.
Archive the logcat logfile.