### PR TITLE
Remove retrolambda.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,6 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$gradle_plugin_version"
 
-        classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
-        configurations.classpath.exclude group: 'com.android.tools.external.lombok'
         classpath 'org.jacoco:org.jacoco.core:0.8.12'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Not sure why we still had it.

It's causing problems now:
```
A problem occurred configuring root project 'poet-assistant'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/me/tatarka/retrolambda/projectlombok/lombok.ast/0.2.3.a2/lombok.ast-0.2.3.a2.pom
       - https://jcenter.bintray.com/me/tatarka/retrolambda/projectlombok/lombok.ast/0.2.3.a2/lombok.ast-0.2.3.a2.pom
     Required by:
         project :
```