### PR TITLE
Improve ci tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,3 +73,11 @@ jobs:
         with:
           name: logcat
           path: /tmp/lolcat.log
+      - name: Archive apks
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: apks
+          path: |
+            ./app/build/outputs/apk/debug/app-debug.apk
+            ./app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk

--- a/scripts/gmsaas-run-tests.py
+++ b/scripts/gmsaas-run-tests.py
@@ -10,8 +10,8 @@ logging.basicConfig(
 )
 parser = argparse.ArgumentParser()
 parser.add_argument("recipe_uuid", type=str)
+parser.add_argument("instance_name", type=str)
 args = parser.parse_args()
-recipe_uuid = args.recipe_uuid
 
 
 def run_gmsaas_command(command: str) -> dict:
@@ -46,10 +46,13 @@ def gmsaas_config():
     logger.info(f"Configuration now {config_set_output["configuration"]}")
 
 
-def gmsaas_start_instance() -> str:
+def gmsaas_start_instance(
+    recipe_uuid: str,
+    instance_name: str,
+) -> str:
     logger.info("Start new instance.")
     instances_start_output = run_gmsaas_command(
-        f"instances start --max-run-duration 30 {recipe_uuid} poet-assistant-tests"
+        f"instances start --max-run-duration 30 {recipe_uuid} '{instance_name}'"
     )
     instance_uuid = instances_start_output["instance"]["uuid"]
     logger.info(f"Started instance {instance_uuid}.")
@@ -110,7 +113,10 @@ def gradle_run_tests() -> int:
 # Setup the device.
 gmsaas_authenticate()
 gmsaas_config()
-instance_uuid = gmsaas_start_instance()
+instance_uuid = gmsaas_start_instance(
+    recipe_uuid=args.recipe_uuid,
+    instance_name=args.instance_name,
+)
 gmsaas_connect_adb(instance_uuid)
 
 # Run the tests.

--- a/scripts/run_tests.bash
+++ b/scripts/run_tests.bash
@@ -1,2 +1,3 @@
 pip install gmsaas==1.12.0
-python ./scripts/gmsaas-run-tests.py ${GMSAAS_RECIPE_UUID}
+instance_name="poet-assistant-tests [${GITHUB_REF_NAME}-${GITHUB_SHA}] [${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}]"
+python ./scripts/gmsaas-run-tests.py ${GMSAAS_RECIPE_UUID} "${instance_name}"


### PR DESCRIPTION
Archive apks in the github actions workflow.

Improve the starting/stopping of gmsaas instances.   
* When starting an instance, specify a max run duration of 30 minutes.
* Don't stop all instances at the beginning and end of tests. Instead, just stop the one instance we started, at the end of the test. Since we specify a max duration, we don't have to worry (as much) about having instances running forever if a test crashes.

This will allow us to run multiple PR builds in parallel.
