### PR TITLE
Bump app version + bump target api level + various minor doc fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change Log
 ==========
 
+Newer release notes are on the [releases](https://github.com/caarmen/poet-assistant/releases) page.
+
 1.30.3  *(2020-10-28)*
 --------------------
 * Android 11: Declare more `<queries>` elements in the manifest

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Poet Assistant
 ==============
 
-[![GitHub Workflow Status (with branch)](https://img.shields.io/github/actions/workflow/status/caarmen/poet-assistant/tests.yaml)](https://github.com/caarmen/poet-assistant/actions/workflows/tests.yml?query=branch%3Amaster)
+[![GitHub Workflow Status (with branch)](https://img.shields.io/github/actions/workflow/status/caarmen/poet-assistant/tests.yaml)](https://github.com/caarmen/poet-assistant/actions/workflows/tests.yaml?query=branch%3Amaster)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/caarmen/poet-assistant)](https://github.com/caarmen/poet-assistant/releases)
 
 [![GitHub repo size](https://img.shields.io/github/repo-size/caarmen/poet-assistant)](https://github.com/caarmen/poet-assistant/archive/refs/heads/main.zip)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,8 +63,8 @@ android {
         namespace "ca.rmen.android.poetassistant"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 113007
-        versionName "1.30.7"
+        versionCode 113008
+        versionName "1.30.8"
         // setting vectorDrawables.useSupportLibrary = true means pngs won't be generated at
         // build time: http://android-developers.blogspot.fr/2016/02/android-support-library-232.html
         vectorDrawables.useSupportLibrary = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 android {
-    compileSdkVersion 34
+    compileSdkVersion 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -62,7 +62,7 @@ android {
         applicationId "ca.rmen.android.poetassistant"
         namespace "ca.rmen.android.poetassistant"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 113008
         versionName "1.30.8"
         // setting vectorDrawables.useSupportLibrary = true means pngs won't be generated at


### PR DESCRIPTION
* Bump app version to 1.30.8.
* Bump targetSdkVersion to 35.
* Update changelog to point to the releases page.
* Fix the link for the build status, in the README.