### PR TITLE
Issue #206: Fix broken insets since targeting Android 15.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,8 +63,8 @@ android {
         namespace "ca.rmen.android.poetassistant"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 113008
-        versionName "1.30.8"
+        versionCode 113009
+        versionName "1.30.9"
         // setting vectorDrawables.useSupportLibrary = true means pngs won't be generated at
         // build time: http://android-developers.blogspot.fr/2016/02/android-support-library-232.html
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/InsetsFix.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/InsetsFix.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Carmen Alvarez
+ *
+ * This file is part of Poet Assistant.
+ *
+ * Poet Assistant is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Poet Assistant is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ca.rmen.android.poetassistant
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
+
+fun fixInsets(view: View) {
+    // Issue #206:
+    // https://developer.android.com/develop/ui/views/layout/edge-to-edge#system-bars-insets
+    ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
+        val insets = windowInsets.getInsets(
+            WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout()
+        )
+        v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+            topMargin = insets.top
+            leftMargin = insets.left
+            bottomMargin = insets.bottom
+            rightMargin = insets.right
+        }
+        WindowInsetsCompat.CONSUMED
+    }
+}

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/InsetsFix.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/InsetsFix.kt
@@ -31,10 +31,21 @@ fun fixInsets(view: View) {
     ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
         val insets = windowInsets.getInsets(
             WindowInsetsCompat.Type.systemBars()
-                    or WindowInsetsCompat.Type.displayCutout()
+                    or WindowInsetsCompat.Type.displayCutout() or WindowInsetsCompat.Type.statusBars()
         )
+        // To control the status bar color, we have to draw a view behind it.
+        // https://developer.android.com/reference/android/view/Window.html#setStatusBarColor(int)
+        // If we have this view, then make it the height of the status bar.
+        val statusBarView = v.findViewById<View>(R.id.status_bar_view)
+        statusBarView?.updateLayoutParams<ViewGroup.LayoutParams> {
+            height = insets.top
+        }
         v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-            topMargin = insets.top
+            // If we don't have a status bar view, we need to shift the content
+            // of the root view down, so it's below the status bar.
+            if (statusBarView == null) {
+                topMargin = insets.top
+            }
             leftMargin = insets.left
             bottomMargin = insets.bottom
             rightMargin = insets.right

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/about/AboutActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/about/AboutActivity.kt
@@ -29,6 +29,7 @@ import android.widget.TextView
 import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.compat.VectorCompat
 import ca.rmen.android.poetassistant.databinding.ActivityAboutBinding
+import ca.rmen.android.poetassistant.fixInsets
 
 class AboutActivity : AppCompatActivity() {
 
@@ -50,6 +51,7 @@ class AboutActivity : AppCompatActivity() {
         val appVersionText = getString(R.string.about_app_version, getString(R.string.app_name), versionName)
         mBinding = DataBindingUtil.setContentView(this, R.layout.activity_about)
         mBinding.txtVersion.text = appVersionText
+        fixInsets(mBinding.root)
         hackSetIcons()
     }
 

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/about/LicenseActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/about/LicenseActivity.kt
@@ -30,6 +30,7 @@ import ca.rmen.android.poetassistant.Constants
 import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.dagger.DaggerHelper
 import ca.rmen.android.poetassistant.databinding.ActivityLicenseBinding
+import ca.rmen.android.poetassistant.fixInsets
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -60,6 +61,7 @@ class LicenseActivity : AppCompatActivity() {
         val title = intent.getStringExtra(EXTRA_TITLE)
         val licenseFile = intent.getStringExtra(EXTRA_LICENSE_TEXT_ASSET_FILE)!!
         mBinding.tvTitle.text = title
+        fixInsets(mBinding.root)
         val threading = DaggerHelper.getMainScreenComponent(this).getThreading()
         threading.execute({ readFile(licenseFile) },
                 { mBinding.tvLicenseText.text = it })

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/ResultListFragment.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/ResultListFragment.kt
@@ -30,6 +30,9 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -42,6 +45,7 @@ import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.compat.VectorCompat
 import ca.rmen.android.poetassistant.databinding.BindingCallbackAdapter
 import ca.rmen.android.poetassistant.databinding.FragmentResultListBinding
+import ca.rmen.android.poetassistant.fixInsets
 import ca.rmen.android.poetassistant.main.AppBarLayoutHelper
 import ca.rmen.android.poetassistant.main.Tab
 import ca.rmen.android.poetassistant.settings.SettingsPrefs
@@ -73,6 +77,7 @@ class ResultListFragment<out T: Any> : Fragment() {
             mBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_result_list, container, false)
             mBinding.recyclerView.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
             mBinding.recyclerView.setHasFixedSize(true)
+            fixInsets(mBinding.recyclerView)
             @Suppress("UNCHECKED_CAST")
             mViewModel = ResultListFactory.createViewModel(it, this) as ResultListViewModel<T>
             mBinding.viewModel = mViewModel

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsActivity.kt
@@ -31,10 +31,14 @@ import android.provider.Settings
 import android.text.TextUtils
 import android.util.Log
 import android.view.View
+import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -49,6 +53,7 @@ import ca.rmen.android.poetassistant.Tts
 import ca.rmen.android.poetassistant.TtsState
 import ca.rmen.android.poetassistant.dagger.DaggerHelper
 import ca.rmen.android.poetassistant.databinding.ActivitySettingsBinding
+import ca.rmen.android.poetassistant.fixInsets
 import ca.rmen.android.poetassistant.main.dictionaries.ConfirmDialogFragment
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
@@ -61,8 +66,9 @@ class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        DataBindingUtil.setContentView<ActivitySettingsBinding>(this, R.layout.activity_settings)
+        val binding = DataBindingUtil.setContentView<ActivitySettingsBinding>(this, R.layout.activity_settings)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        fixInsets(binding.root)
         volumeControlStream = AudioManager.STREAM_MUSIC
     }
 

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -20,132 +20,143 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <FrameLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".about.AboutActivity">
+        android:orientation="vertical">
+        <View
+            android:id="@+id/status_bar_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="?colorPrimary" />
 
-        <ImageView
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:alpha="0.2"
-            android:contentDescription="@string/app_name"
-            android:scaleType="fitEnd"
-            android:src="@mipmap/ic_launcher" />
+            tools:context=".about.AboutActivity">
 
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <LinearLayout
+            <ImageView
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="8dp">
+                android:layout_height="match_parent"
+                android:alpha="0.2"
+                android:contentDescription="@string/app_name"
+                android:scaleType="fitEnd"
+                android:src="@mipmap/ic_launcher" />
 
-                <TextView
-                    android:id="@+id/txtVersion"
-                    android:layout_width="wrap_content"
+            <ScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:gravity="center_vertical"
-                    android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:textStyle="bold" />
+                    android:orientation="vertical"
+                    android:padding="8dp">
 
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
-                    android:autoLink="all"
-                    android:gravity="center_vertical"
-                    android:text="@string/about_copyright"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColorLink="@color/primary" />
+                    <TextView
+                        android:id="@+id/txtVersion"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:textAppearance="?android:attr/textAppearanceMedium"
+                        android:textStyle="bold" />
 
-                <TextView
-                    style="@style/AboutActivityItem"
-                    android:id="@+id/tv_source_code"
-                    android:text="@string/about_projectUrl"/>
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:autoLink="all"
+                        android:gravity="center_vertical"
+                        android:text="@string/about_copyright"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textColorLink="@color/primary" />
 
-                <TextView
-                    style="@style/AboutActivityItem"
-                    android:id="@+id/tv_bug_report"
-                    android:text="@string/about_issuesUrl"/>
+                    <TextView
+                        style="@style/AboutActivityItem"
+                        android:id="@+id/tv_source_code"
+                        android:text="@string/about_projectUrl"/>
 
-                <TextView
-                    style="@style/AboutActivityItem"
-                    android:id="@+id/tv_rate"
-                    android:text="@string/about_rateUrl"/>
+                    <TextView
+                        style="@style/AboutActivityItem"
+                        android:id="@+id/tv_bug_report"
+                        android:text="@string/about_issuesUrl"/>
 
-                <TextView
-                    style="@style/AboutActivityItem"
-                    android:id="@+id/tv_legal"
-                    android:text="@string/about_legal"/>
+                    <TextView
+                        style="@style/AboutActivityItem"
+                        android:id="@+id/tv_rate"
+                        android:text="@string/about_rateUrl"/>
 
-                <TextView
-                    style="@style/AboutActivitySubItem"
-                    android:id="@+id/tv_privacy_policy"
-                    android:text="@string/about_privacy_policy"/>
+                    <TextView
+                        style="@style/AboutActivityItem"
+                        android:id="@+id/tv_legal"
+                        android:text="@string/about_legal"/>
 
-                <TextView
-                    style="@style/AboutActivitySubItem"
-                    android:id="@+id/tv_poet_assistant_license"
-                    android:onClick="onClickAppLicense"
-                    android:text="@string/about_license_app"
-                    android:textColor="@color/primary" />
+                    <TextView
+                        style="@style/AboutActivitySubItem"
+                        android:id="@+id/tv_privacy_policy"
+                        android:text="@string/about_privacy_policy"/>
 
-                <TextView
-                    android:id="@+id/tv_rhymer_license"
-                    style="@style/AboutActivitySubItem"
-                    android:onClick="onClickRhymerLicense"
-                    android:text="@string/about_license_rhyming_dictionary"
-                    android:textColor="@color/primary" />
+                    <TextView
+                        style="@style/AboutActivitySubItem"
+                        android:id="@+id/tv_poet_assistant_license"
+                        android:onClick="onClickAppLicense"
+                        android:text="@string/about_license_app"
+                        android:textColor="@color/primary" />
 
-                <TextView
-                    android:id="@+id/tv_thesaurus_license"
-                    style="@style/AboutActivitySubItem"
-                    android:onClick="onClickThesaurusLicense"
-                    android:text="@string/about_license_thesaurus"
-                    android:textColor="@color/primary" />
+                    <TextView
+                        android:id="@+id/tv_rhymer_license"
+                        style="@style/AboutActivitySubItem"
+                        android:onClick="onClickRhymerLicense"
+                        android:text="@string/about_license_rhyming_dictionary"
+                        android:textColor="@color/primary" />
 
-                <TextView
-                    android:id="@+id/tv_dictionary_license"
-                    style="@style/AboutActivitySubItem"
-                    android:onClick="onClickDictionaryLicense"
-                    android:text="@string/about_license_dictionary"
-                    android:textColor="@color/primary" />
+                    <TextView
+                        android:id="@+id/tv_thesaurus_license"
+                        style="@style/AboutActivitySubItem"
+                        android:onClick="onClickThesaurusLicense"
+                        android:text="@string/about_license_thesaurus"
+                        android:textColor="@color/primary" />
 
-                <TextView
-                    android:id="@+id/tv_google_ngram_dataset_license"
-                    style="@style/AboutActivitySubItem"
-                    android:onClick="onClickGoogleNgramDatasetLicense"
-                    android:text="@string/about_license_google_ngram_dataset"
-                    android:textColor="@color/primary" />
+                    <TextView
+                        android:id="@+id/tv_dictionary_license"
+                        style="@style/AboutActivitySubItem"
+                        android:onClick="onClickDictionaryLicense"
+                        android:text="@string/about_license_dictionary"
+                        android:textColor="@color/primary" />
 
-                <TextView
-                    style="@style/AboutActivitySubItem"
-                    android:id="@+id/tv_support_lib_license"
-                    android:text="@string/about_license_support_lib"/>
+                    <TextView
+                        android:id="@+id/tv_google_ngram_dataset_license"
+                        style="@style/AboutActivitySubItem"
+                        android:onClick="onClickGoogleNgramDatasetLicense"
+                        android:text="@string/about_license_google_ngram_dataset"
+                        android:textColor="@color/primary" />
 
-                <TextView
-                    style="@style/AboutActivitySubItem"
-                    android:id="@+id/tv_dagger_license"
-                    android:text="@string/about_license_dagger"/>
+                    <TextView
+                        style="@style/AboutActivitySubItem"
+                        android:id="@+id/tv_support_lib_license"
+                        android:text="@string/about_license_support_lib"/>
 
-                <TextView
-                    style="@style/AboutActivitySubItem"
-                    android:id="@+id/tv_kotlin_license"
-                    android:text="@string/about_license_kotlin"/>
+                    <TextView
+                        style="@style/AboutActivitySubItem"
+                        android:id="@+id/tv_dagger_license"
+                        android:text="@string/about_license_dagger"/>
 
-                <TextView
-                    style="@style/AboutActivitySubItem"
-                    android:id="@+id/tv_prefs_license"
-                    android:text="@string/about_license_prefs"/>
+                    <TextView
+                        style="@style/AboutActivitySubItem"
+                        android:id="@+id/tv_kotlin_license"
+                        android:text="@string/about_license_kotlin"/>
 
-                <TextView
-                    style="@style/AboutActivitySubItem"
-                    android:id="@+id/tv_stemmer_license"
-                    android:text="@string/about_porter_stemming_algorithm"/>
-            </LinearLayout>
-        </ScrollView>
-    </FrameLayout>
+                    <TextView
+                        style="@style/AboutActivitySubItem"
+                        android:id="@+id/tv_prefs_license"
+                        android:text="@string/about_license_prefs"/>
+
+                    <TextView
+                        style="@style/AboutActivitySubItem"
+                        android:id="@+id/tv_stemmer_license"
+                        android:text="@string/about_porter_stemming_algorithm"/>
+                </LinearLayout>
+            </ScrollView>
+        </FrameLayout>
+    </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/activity_license.xml
+++ b/app/src/main/res/layout/activity_license.xml
@@ -20,44 +20,55 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools">
 
-    <ScrollView
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".about.LicenseActivity">
+        android:orientation="vertical">
+        <View
+            android:id="@+id/status_bar_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="?colorPrimary" />
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:context=".about.LicenseActivity">
 
 
-        <HorizontalScrollView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
-
-            <LinearLayout
+            <HorizontalScrollView
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="8dp"
-                android:orientation="vertical"
-                android:padding="8dp">
+                android:layout_height="wrap_content">
 
-                <TextView
-                    android:id="@+id/tv_title"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="16dp"
-                    android:gravity="center_vertical"
-                    android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:textStyle="bold"
-                    tools:text="License title"/>
+                    android:layout_margin="8dp"
+                    android:orientation="vertical"
+                    android:padding="8dp">
 
-                <TextView
-                    android:id="@+id/tv_license_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:autoLink="web"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColorLink="@color/primary"
-                    tools:text="@tools:sample/lorem/random"/>
+                    <TextView
+                        android:id="@+id/tv_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
+                        android:gravity="center_vertical"
+                        android:textAppearance="?android:attr/textAppearanceMedium"
+                        android:textStyle="bold"
+                        tools:text="License title"/>
 
-            </LinearLayout>
+                    <TextView
+                        android:id="@+id/tv_license_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:autoLink="web"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textColorLink="@color/primary"
+                        tools:text="@tools:sample/lorem/random"/>
 
-        </HorizontalScrollView>
-    </ScrollView>
+                </LinearLayout>
+
+            </HorizontalScrollView>
+        </ScrollView>
+    </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,6 +35,7 @@
             android:id="@+id/app_bar_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:fitsSystemWindows="true"
             android:theme="@style/AppTheme.AppBarOverlay">
 
             <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -20,8 +20,15 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
 
     <LinearLayout
+        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
+        <View
+            android:id="@+id/status_bar_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="?colorPrimary" />
 
         <fragment
             android:id="@+id/settings_fragment"


### PR DESCRIPTION
Issue:
* #206 

Fix `AppBarLayout` insets.

We're hitting this behavior change when targeting Android 15: https://developer.android.com/about/versions/15/behavior-changes-15#not-edge-to-edge

The documentation says:
> you need to add android:fitsSystemWindows="true" if using AppBarLayout.

Also:
* Apply a code snippet to various other screens not using `AppBarLayout`: to ensure that the top and bottom aren't hidden under the system bars.
* Make the system status bar have our app's theme color. To do this, draw a view with our app's color, and make it the size of the status bar.



||1.30.7|1.30.8|This PR|
|---|---|---|---|
|Android 15 list|<img width="540" alt="image" src="https://github.com/user-attachments/assets/449d7977-b830-40d4-97b3-3d83d0f1577b">|<img width="540" alt="image" src="https://github.com/user-attachments/assets/ee9e6133-7c67-4181-8be7-138d49e7ba0d">|<img width="540" alt="image" src="https://github.com/user-attachments/assets/b8ff12fb-b996-48ca-bb7c-cfcb9c763422">|
|Android 15 settings|<img width="540" alt="image" src="https://github.com/user-attachments/assets/84d2eaf7-49e4-4560-a176-05f05895a4e2">|<img width="540" alt="image" src="https://github.com/user-attachments/assets/911de056-95c4-4f09-93d2-c119d45f49e6">|<img width="540" alt="image" src="https://github.com/user-attachments/assets/e52e8191-3bc6-4ccc-9a08-1c329620d48f">|
|Android 5.0 list|<img width="553" alt="image" src="https://github.com/user-attachments/assets/572458ba-1c9f-43f7-99f5-525fc3a411bf">|<img width="553" alt="image" src="https://github.com/user-attachments/assets/7315c34c-4f9c-4a42-8394-d36073296b74">|<img width="553" alt="image" src="https://github.com/user-attachments/assets/4a3f8efa-1ac1-4625-92dc-e292ebab9661">|
|Android 5.0 settings|<img width="553" alt="image" src="https://github.com/user-attachments/assets/6f6890af-42d5-4955-9872-be910aca5625">|<img width="553" alt="image" src="https://github.com/user-attachments/assets/a300027a-74d5-400f-a3b0-82025f6778c4">|<img width="553" alt="image" src="https://github.com/user-attachments/assets/65076d35-9d05-4ba2-9c31-a09b60c99907">|







