### PR TITLE
Issue #206: Fix various insets

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,8 +63,8 @@ android {
         namespace "ca.rmen.android.poetassistant"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 113009
-        versionName "1.30.9"
+        versionCode 113010
+        versionName "1.30.10"
         // setting vectorDrawables.useSupportLibrary = true means pngs won't be generated at
         // build time: http://android-developers.blogspot.fr/2016/02/android-support-library-232.html
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/InsetsFix.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/InsetsFix.kt
@@ -21,11 +21,12 @@ package ca.rmen.android.poetassistant
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
 
-fun fixInsets(view: View) {
+fun getInsets(view: View, callback: (view: View, insets: Insets) -> Unit) {
     // Issue #206:
     // https://developer.android.com/develop/ui/views/layout/edge-to-edge#system-bars-insets
     ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
@@ -33,23 +34,17 @@ fun fixInsets(view: View) {
             WindowInsetsCompat.Type.systemBars()
                     or WindowInsetsCompat.Type.displayCutout() or WindowInsetsCompat.Type.statusBars()
         )
-        // To control the status bar color, we have to draw a view behind it.
-        // https://developer.android.com/reference/android/view/Window.html#setStatusBarColor(int)
-        // If we have this view, then make it the height of the status bar.
-        val statusBarView = v.findViewById<View>(R.id.status_bar_view)
-        statusBarView?.updateLayoutParams<ViewGroup.LayoutParams> {
-            height = insets.top
-        }
-        v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-            // If we don't have a status bar view, we need to shift the content
-            // of the root view down, so it's below the status bar.
-            if (statusBarView == null) {
-                topMargin = insets.top
-            }
-            leftMargin = insets.left
-            bottomMargin = insets.bottom
-            rightMargin = insets.right
-        }
+        callback(v, insets)
         WindowInsetsCompat.CONSUMED
     }
 }
+
+fun fixStatusBarViewForInsets(statusBarView: View, insets: Insets) {
+    // To control the status bar color, we have to draw a view behind it.
+    // Make it the height of the status bar.
+    // https://developer.android.com/reference/android/view/Window.html#setStatusBarColor(int)
+    statusBarView.updateLayoutParams<ViewGroup.LayoutParams> {
+        height = insets.top
+    }
+}
+

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/about/AboutActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/about/AboutActivity.kt
@@ -26,10 +26,12 @@ import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AppCompatActivity
 import android.view.View
 import android.widget.TextView
+import androidx.core.view.updatePadding
 import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.compat.VectorCompat
 import ca.rmen.android.poetassistant.databinding.ActivityAboutBinding
-import ca.rmen.android.poetassistant.fixInsets
+import ca.rmen.android.poetassistant.fixStatusBarViewForInsets
+import ca.rmen.android.poetassistant.getInsets
 
 class AboutActivity : AppCompatActivity() {
 
@@ -51,7 +53,14 @@ class AboutActivity : AppCompatActivity() {
         val appVersionText = getString(R.string.about_app_version, getString(R.string.app_name), versionName)
         mBinding = DataBindingUtil.setContentView(this, R.layout.activity_about)
         mBinding.txtVersion.text = appVersionText
-        fixInsets(mBinding.root)
+        getInsets(mBinding.aboutContent) { view, insets ->
+            view.updatePadding(
+                left = insets.left,
+                right = insets.right,
+                bottom = insets.bottom,
+            )
+            fixStatusBarViewForInsets(mBinding.statusBarView, insets)
+        }
         hackSetIcons()
     }
 

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/about/LicenseActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/about/LicenseActivity.kt
@@ -25,12 +25,14 @@ import android.os.Bundle
 import android.util.Log
 import androidx.annotation.WorkerThread
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.updatePadding
 import androidx.databinding.DataBindingUtil
 import ca.rmen.android.poetassistant.Constants
 import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.dagger.DaggerHelper
 import ca.rmen.android.poetassistant.databinding.ActivityLicenseBinding
-import ca.rmen.android.poetassistant.fixInsets
+import ca.rmen.android.poetassistant.fixStatusBarViewForInsets
+import ca.rmen.android.poetassistant.getInsets
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -61,7 +63,14 @@ class LicenseActivity : AppCompatActivity() {
         val title = intent.getStringExtra(EXTRA_TITLE)
         val licenseFile = intent.getStringExtra(EXTRA_LICENSE_TEXT_ASSET_FILE)!!
         mBinding.tvTitle.text = title
-        fixInsets(mBinding.root)
+        getInsets(mBinding.licenseContent) { view, insets ->
+            view.updatePadding(
+                left = insets.left,
+                right = insets.right,
+                bottom = insets.bottom,
+            )
+            fixStatusBarViewForInsets(mBinding.statusBarView, insets)
+        }
         val threading = DaggerHelper.getMainScreenComponent(this).getThreading()
         threading.execute({ readFile(licenseFile) },
                 { mBinding.tvLicenseText.text = it })

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/MainActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/MainActivity.kt
@@ -40,6 +40,7 @@ import android.view.MenuItem
 import android.view.Window
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
+import androidx.core.view.updatePadding
 import ca.rmen.android.poetassistant.BuildConfig
 import ca.rmen.android.poetassistant.Constants
 import ca.rmen.android.poetassistant.Favorites
@@ -48,6 +49,7 @@ import ca.rmen.android.poetassistant.Threading
 import ca.rmen.android.poetassistant.about.AboutActivity
 import ca.rmen.android.poetassistant.dagger.DaggerHelper
 import ca.rmen.android.poetassistant.databinding.ActivityMainBinding
+import ca.rmen.android.poetassistant.getInsets
 import ca.rmen.android.poetassistant.main.dictionaries.ResultListFragment
 import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary
 import ca.rmen.android.poetassistant.main.dictionaries.rt.OnWordClickListener
@@ -119,6 +121,19 @@ class MainActivity : AppCompatActivity(), OnWordClickListener, WarningNoSpaceDia
                     }
                 })
         volumeControlStream = AudioManager.STREAM_MUSIC
+        getInsets(mBinding.toolbar) { view, insets ->
+            view.updatePadding(
+                left = insets.left,
+                right = insets.right,
+            )
+        }
+        getInsets(mBinding.appBarLayout) { view, insets ->
+            view.updatePadding(
+                left = insets.left,
+                right = insets.right,
+                top = insets.top,
+            )
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/ResultListFragment.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/ResultListFragment.kt
@@ -30,9 +30,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updatePadding
+import androidx.core.view.updateLayoutParams
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -45,7 +43,7 @@ import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.compat.VectorCompat
 import ca.rmen.android.poetassistant.databinding.BindingCallbackAdapter
 import ca.rmen.android.poetassistant.databinding.FragmentResultListBinding
-import ca.rmen.android.poetassistant.fixInsets
+import ca.rmen.android.poetassistant.getInsets
 import ca.rmen.android.poetassistant.main.AppBarLayoutHelper
 import ca.rmen.android.poetassistant.main.Tab
 import ca.rmen.android.poetassistant.settings.SettingsPrefs
@@ -77,7 +75,13 @@ class ResultListFragment<out T: Any> : Fragment() {
             mBinding = DataBindingUtil.inflate(inflater, R.layout.fragment_result_list, container, false)
             mBinding.recyclerView.layoutManager = LinearLayoutManager(activity, RecyclerView.VERTICAL, false)
             mBinding.recyclerView.setHasFixedSize(true)
-            fixInsets(mBinding.recyclerView)
+            getInsets(mBinding.recyclerView) { view, insets ->
+                view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    leftMargin = insets.left
+                    bottomMargin = insets.bottom
+                    rightMargin = insets.right
+                }
+            }
             @Suppress("UNCHECKED_CAST")
             mViewModel = ResultListFactory.createViewModel(it, this) as ResultListViewModel<T>
             mBinding.viewModel = mViewModel

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsActivity.kt
@@ -35,6 +35,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.view.updatePadding
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -49,7 +50,8 @@ import ca.rmen.android.poetassistant.Tts
 import ca.rmen.android.poetassistant.TtsState
 import ca.rmen.android.poetassistant.dagger.DaggerHelper
 import ca.rmen.android.poetassistant.databinding.ActivitySettingsBinding
-import ca.rmen.android.poetassistant.fixInsets
+import ca.rmen.android.poetassistant.getInsets
+import ca.rmen.android.poetassistant.fixStatusBarViewForInsets
 import ca.rmen.android.poetassistant.main.dictionaries.ConfirmDialogFragment
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
@@ -64,7 +66,14 @@ class SettingsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         val binding = DataBindingUtil.setContentView<ActivitySettingsBinding>(this, R.layout.activity_settings)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        fixInsets(binding.root)
+        getInsets(binding.settingsFragment) { view, insets ->
+            view.updatePadding(
+                left = insets.left,
+                right = insets.right,
+                bottom = insets.bottom,
+            )
+            fixStatusBarViewForInsets(binding.statusBarView, insets)
+        }
         volumeControlStream = AudioManager.STREAM_MUSIC
     }
 

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsActivity.kt
@@ -31,14 +31,10 @@ import android.provider.Settings
 import android.text.TextUtils
 import android.util.Log
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.updateLayoutParams
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -31,6 +31,7 @@
             android:background="?colorPrimary" />
 
         <FrameLayout
+            android:id="@+id/about_content"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             tools:context=".about.AboutActivity">

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -34,6 +34,7 @@
             android:id="@+id/about_content"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:clipToPadding="false"
             tools:context=".about.AboutActivity">
 
             <ImageView

--- a/app/src/main/res/layout/activity_license.xml
+++ b/app/src/main/res/layout/activity_license.xml
@@ -34,6 +34,7 @@
             android:id="@+id/license_content"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:clipToPadding="false"
             tools:context=".about.LicenseActivity">
 
 

--- a/app/src/main/res/layout/activity_license.xml
+++ b/app/src/main/res/layout/activity_license.xml
@@ -31,6 +31,7 @@
             android:background="?colorPrimary" />
 
         <ScrollView
+            android:id="@+id/license_content"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             tools:context=".about.LicenseActivity">

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -30,7 +30,7 @@
             android:layout_height="0dp"
             android:background="?colorPrimary" />
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/settings_fragment"
             android:name="ca.rmen.android.poetassistant.settings.SettingsActivity$GeneralPreferenceFragment"
             android:layout_width="match_parent"


### PR DESCRIPTION
The previous approach assumed we'd need similar inset adjustments to the root view, in all screens.
    
Each screen is a bit different. Adjust the padding/margins of views per the insets, for each screen accordingly.



||1.30.9|1.30.10 (this PR)|
|---|---|---|
|list portrait|<img width="540" alt="image" src="https://github.com/user-attachments/assets/a90c3d64-2f0d-4210-a103-80b298fa38aa">|<img width="540" alt="image" src="https://github.com/user-attachments/assets/020e0410-2ef4-4112-a533-7829ed187e71">|
|list landscape|<img width="1068" alt="image" src="https://github.com/user-attachments/assets/eb5d2efb-5f99-43e3-a439-fb816c56eb9f">|<img width="1068" alt="image" src="https://github.com/user-attachments/assets/c788649d-a0dd-49c0-8cfc-85a0801280e3">|
|settings landscape|<img width="1068" alt="image" src="https://github.com/user-attachments/assets/51075ecb-d6f9-406c-807f-8bcf7fb9d32a">|<img width="1068" alt="image" src="https://github.com/user-attachments/assets/6a788fa1-58f7-4cb7-8429-62d6e5fb3855">|
|about landscape|<img width="1068" alt="image" src="https://github.com/user-attachments/assets/4f2ea02f-2a75-45a2-bb0a-fc22c18f109c">|<img width="1068" alt="image" src="https://github.com/user-attachments/assets/fc33541f-a1d8-4f2c-bfb8-72c27ab71c53">|
|license portrait|<img width="540" alt="image" src="https://github.com/user-attachments/assets/744289d4-25a5-4c81-aab2-774967b5c6d8">|<img width="540" alt="image" src="https://github.com/user-attachments/assets/6c542f7a-3c6e-4cee-9e2c-77111da8ca03">|
|license landscape|<img width="1068" alt="image" src="https://github.com/user-attachments/assets/39ab88aa-a38f-4d28-8952-685aaf2d0214">|<img width="1068" alt="image" src="https://github.com/user-attachments/assets/81b08c68-9ae4-4569-95d9-956860475b81">|




