### PR TITLE
More repository refactoring (favorites + suggestions)

### DIFF
--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/FavoriteDao.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/FavoriteDao.kt
@@ -30,7 +30,7 @@ import androidx.room.Query
 interface FavoriteDao {
 
     @Query("SELECT * FROM FAVORITE")
-    fun getFavorites(): Array<Favorite>
+    suspend fun getFavorites(): Array<Favorite>
 
     @Query("SELECT * FROM FAVORITE")
     fun getFavoritesLiveData(): LiveData<List<Favorite>>

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/FavoritesRepository.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/FavoritesRepository.kt
@@ -49,9 +49,8 @@ class FavoritesRepository(
 
     fun getFavoritesLiveData(): LiveData<List<Favorite>> = favoriteDao.getFavoritesLiveData()
 
-    @WorkerThread
-    fun getFavorites(): Set<String> {
-        return favoriteDao.getFavorites().map(Favorite::getWord).toSet()
+    suspend fun getFavorites(): Set<String> = withContext(ioDispatcher) {
+        favoriteDao.getFavorites().map(Favorite::getWord).toSet()
     }
 
     @WorkerThread

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/FavoritesRepository.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/FavoritesRepository.kt
@@ -23,7 +23,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import android.content.Context
 import android.net.Uri
-import androidx.annotation.WorkerThread
 import android.text.TextUtils
 import android.util.Log
 import kotlinx.coroutines.CoroutineDispatcher
@@ -53,7 +52,6 @@ class FavoritesRepository(
         favoriteDao.getFavorites().map(Favorite::getWord).toSet()
     }
 
-    @WorkerThread
     @Throws(IOException::class)
     suspend fun exportFavorites(context: Context, uri: Uri) {
         withContext(ioDispatcher) {
@@ -73,7 +71,6 @@ class FavoritesRepository(
         else removeFavorite(word)
     }
 
-    @WorkerThread
     @Throws(IOException::class)
     suspend fun importFavorites(context: Context, uri: Uri) {
         withContext(ioDispatcher) {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/di/AppModule.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/di/AppModule.kt
@@ -79,6 +79,6 @@ class AppModule {
 
     @Provides
     @Singleton
-    fun providesSuggestions(userDb: UserDb) = Suggestions(userDb.suggestionDao())
+    fun providesSuggestions(userDb: UserDb, @IODispatcher ioDispatcher: CoroutineDispatcher) = Suggestions(userDb.suggestionDao(), ioDispatcher)
 
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/di/AppModule.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/di/AppModule.kt
@@ -27,7 +27,7 @@ import ca.rmen.android.poetassistant.main.dictionaries.EmbeddedDb
 import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary
 import ca.rmen.android.poetassistant.main.dictionaries.rt.Rhymer
 import ca.rmen.android.poetassistant.main.dictionaries.rt.Thesaurus
-import ca.rmen.android.poetassistant.main.dictionaries.search.Suggestions
+import ca.rmen.android.poetassistant.main.dictionaries.search.SuggestionsRepository
 import ca.rmen.android.poetassistant.settings.SettingsPrefs
 import dagger.Module
 import dagger.Provides
@@ -79,6 +79,6 @@ class AppModule {
 
     @Provides
     @Singleton
-    fun providesSuggestions(userDb: UserDb, embeddedDb: EmbeddedDb, @IODispatcher ioDispatcher: CoroutineDispatcher) = Suggestions(userDb.suggestionDao(), embeddedDb, ioDispatcher)
+    fun providesSuggestions(userDb: UserDb, embeddedDb: EmbeddedDb, @IODispatcher ioDispatcher: CoroutineDispatcher) = SuggestionsRepository(userDb.suggestionDao(), embeddedDb, ioDispatcher)
 
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/di/AppModule.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/di/AppModule.kt
@@ -79,6 +79,6 @@ class AppModule {
 
     @Provides
     @Singleton
-    fun providesSuggestions(userDb: UserDb, @IODispatcher ioDispatcher: CoroutineDispatcher) = Suggestions(userDb.suggestionDao(), ioDispatcher)
+    fun providesSuggestions(userDb: UserDb, embeddedDb: EmbeddedDb, @IODispatcher ioDispatcher: CoroutineDispatcher) = Suggestions(userDb.suggestionDao(), embeddedDb, ioDispatcher)
 
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/di/NonAndroidEntryPoint.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/di/NonAndroidEntryPoint.kt
@@ -5,7 +5,7 @@ import ca.rmen.android.poetassistant.Tts
 import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary
 import ca.rmen.android.poetassistant.main.dictionaries.rt.Rhymer
 import ca.rmen.android.poetassistant.main.dictionaries.rt.Thesaurus
-import ca.rmen.android.poetassistant.main.dictionaries.search.Suggestions
+import ca.rmen.android.poetassistant.main.dictionaries.search.SuggestionsRepository
 import ca.rmen.android.poetassistant.settings.SettingsPrefs
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -24,7 +24,7 @@ interface NonAndroidEntryPoint {
     fun thesaurus(): Thesaurus
     fun dictionary(): Dictionary
     fun favoritesRepository(): FavoritesRepository
-    fun suggestions(): Suggestions
+    fun suggestionsRepository(): SuggestionsRepository
     fun prefs(): SettingsPrefs
     @IODispatcher fun ioDispatcher(): CoroutineDispatcher
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/di/NonAndroidEntryPoint.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/di/NonAndroidEntryPoint.kt
@@ -23,7 +23,7 @@ interface NonAndroidEntryPoint {
     fun rhymer(): Rhymer
     fun thesaurus(): Thesaurus
     fun dictionary(): Dictionary
-    fun favorites(): FavoritesRepository
+    fun favoritesRepository(): FavoritesRepository
     fun suggestions(): Suggestions
     fun prefs(): SettingsPrefs
     @IODispatcher fun ioDispatcher(): CoroutineDispatcher

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/MainActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/MainActivity.kt
@@ -55,7 +55,7 @@ import ca.rmen.android.poetassistant.main.dictionaries.rt.OnWordClickListener
 import ca.rmen.android.poetassistant.main.dictionaries.rt.Rhymer
 import ca.rmen.android.poetassistant.main.dictionaries.rt.Thesaurus
 import ca.rmen.android.poetassistant.main.dictionaries.search.Search
-import ca.rmen.android.poetassistant.main.dictionaries.search.Suggestions
+import ca.rmen.android.poetassistant.main.dictionaries.search.SuggestionsRepository
 import ca.rmen.android.poetassistant.main.dictionaries.search.SuggestionsViewModel
 import ca.rmen.android.poetassistant.main.reader.ReaderFragment
 import ca.rmen.android.poetassistant.settings.SettingsActivity
@@ -87,7 +87,7 @@ open class MainActivityImpl : AppCompatActivity(), OnWordClickListener, WarningN
     @Inject lateinit var mThesaurus: Thesaurus
     @Inject lateinit var mDictionary: Dictionary
     @Inject lateinit var mFavoritesRepository: FavoritesRepository
-    @Inject lateinit var suggestions: Suggestions
+    @Inject lateinit var suggestionsRepository: SuggestionsRepository
 
     @IODispatcher @Inject lateinit var ioDispatcher: CoroutineDispatcher
 
@@ -123,7 +123,7 @@ open class MainActivityImpl : AppCompatActivity(), OnWordClickListener, WarningN
             mBinding.viewPager.setCurrentItem(mPagerAdapter.getPositionForTab(Tab.READER), false)
         }
 
-        mSearch = Search(this, mBinding.viewPager, dictionary = mDictionary, suggestions = suggestions)
+        mSearch = Search(this, mBinding.viewPager, dictionary = mDictionary, suggestionsRepository = suggestionsRepository)
         // Load our dictionaries when the activity starts, so that the first search can already be fast.
         lifecycleScope.launch {
             val dbLoaded = loadDatabase()

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/MainActivity.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/MainActivity.kt
@@ -55,6 +55,7 @@ import ca.rmen.android.poetassistant.main.dictionaries.rt.OnWordClickListener
 import ca.rmen.android.poetassistant.main.dictionaries.rt.Rhymer
 import ca.rmen.android.poetassistant.main.dictionaries.rt.Thesaurus
 import ca.rmen.android.poetassistant.main.dictionaries.search.Search
+import ca.rmen.android.poetassistant.main.dictionaries.search.Suggestions
 import ca.rmen.android.poetassistant.main.dictionaries.search.SuggestionsViewModel
 import ca.rmen.android.poetassistant.main.reader.ReaderFragment
 import ca.rmen.android.poetassistant.settings.SettingsActivity
@@ -86,6 +87,7 @@ open class MainActivityImpl : AppCompatActivity(), OnWordClickListener, WarningN
     @Inject lateinit var mThesaurus: Thesaurus
     @Inject lateinit var mDictionary: Dictionary
     @Inject lateinit var mFavoritesRepository: FavoritesRepository
+    @Inject lateinit var suggestions: Suggestions
 
     @IODispatcher @Inject lateinit var ioDispatcher: CoroutineDispatcher
 
@@ -121,7 +123,7 @@ open class MainActivityImpl : AppCompatActivity(), OnWordClickListener, WarningN
             mBinding.viewPager.setCurrentItem(mPagerAdapter.getPositionForTab(Tab.READER), false)
         }
 
-        mSearch = Search(this, mBinding.viewPager, dictionary = mDictionary, ioDispatcher =  ioDispatcher)
+        mSearch = Search(this, mBinding.viewPager, dictionary = mDictionary, suggestions = suggestions)
         // Load our dictionaries when the activity starts, so that the first search can already be fast.
         lifecycleScope.launch {
             val dbLoaded = loadDatabase()

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/ResultListLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/ResultListLiveData.kt
@@ -33,7 +33,7 @@ abstract class ResultListLiveData<T> protected constructor(
 ) : LiveData<T>() {
     private var mIsLoading = false
 
-    protected abstract fun loadInBackground(): T
+    protected abstract suspend fun loadInBackground(): T
     override fun onActive() {
         if (value == null && !mIsLoading) {
             mIsLoading = true

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/dictionary/Dictionary.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/dictionary/Dictionary.kt
@@ -41,7 +41,6 @@ class Dictionary @Inject constructor(
         private const val MIN_INTERESTING_FREQUENCY = 1500
         private const val MAX_INTERESTING_FREQUENCY = 25000
 
-        private const val MAX_PREFIX_MATCHES = 10
     }
 
     fun isLoaded(): Boolean = embeddedDb.isLoaded()
@@ -84,36 +83,16 @@ class Dictionary @Inject constructor(
         val selectionArgs = arrayOf(pattern)
         val orderBy = "word"
         val limit = Constants.MAX_RESULTS.toString()
-        embeddedDb.query(true, "dictionary", projection, selection, selectionArgs, orderBy, limit)?.use { cursor ->
-            if (cursor.count > 0) {
-                val result = Array(cursor.count) { "" }
-                while (cursor.moveToNext()) {
-                    result[cursor.position] = cursor.getString(0)
+        embeddedDb.query(true, "dictionary", projection, selection, selectionArgs, orderBy, limit)
+            ?.use { cursor ->
+                if (cursor.count > 0) {
+                    val result = Array(cursor.count) { "" }
+                    while (cursor.moveToNext()) {
+                        result[cursor.position] = cursor.getString(0)
+                    }
+                    return result
                 }
-                return result
             }
-        }
-        return emptyArray()
-    }
-
-    /**
-     * @return at most limit words starting with the given prefix
-     */
-    fun findWordsWithPrefix(prefix: String): Array<String> {
-        val projection = arrayOf("word")
-        val selection = "has_definition=1 AND word LIKE ?"
-        val selectionArgs = arrayOf("$prefix%")
-        val orderBy = "word"
-        embeddedDb.query(true, "word_variants", projection, selection, selectionArgs,
-                orderBy, MAX_PREFIX_MATCHES.toString())?.use { cursor ->
-            if (cursor.count > 0) {
-                val result = Array(cursor.count) { "" }
-                while (cursor.moveToNext()) {
-                    result[cursor.position] = cursor.getString(0)
-                }
-                return result
-            }
-        }
         return emptyArray()
     }
 

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/dictionary/DictionaryLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/dictionary/DictionaryLiveData.kt
@@ -34,7 +34,7 @@ class DictionaryLiveData(context: Context, coroutineScope: CoroutineScope, priva
         private val TAG = Constants.TAG + DictionaryLiveData::class.java.simpleName
     }
 
-    override fun loadInBackground(): ResultListData<DictionaryEntry.DictionaryEntryDetails> {
+    override suspend fun loadInBackground(): ResultListData<DictionaryEntry.DictionaryEntryDetails> {
         Log.v(TAG, "loadInBackground: query=$query")
         val result = ArrayList<DictionaryEntry.DictionaryEntryDetails>()
         if (TextUtils.isEmpty(query)) return ResultListData(query, result)

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/FavoritesLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/FavoritesLiveData.kt
@@ -50,7 +50,7 @@ class FavoritesLiveData(
         mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
-    override fun loadInBackground(): ResultListData<RTListItem> {
+    override suspend fun loadInBackground(): ResultListData<RTListItem> {
         Log.d(TAG, "loadInBackground")
         val data = ArrayList<RTListItem>()
         val favorites = mFavoritesRepository.getFavorites()

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/FavoritesLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/FavoritesLiveData.kt
@@ -47,7 +47,7 @@ class FavoritesLiveData(
     init {
         val entryPoint = EntryPointAccessors.fromApplication(context.applicationContext, NonAndroidEntryPoint::class.java)
         mPrefs = entryPoint.prefs()
-        mFavoritesRepository = entryPoint.favorites()
+        mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
     override fun loadInBackground(): ResultListData<RTListItem> {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/PatternLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/PatternLiveData.kt
@@ -55,7 +55,7 @@ class PatternLiveData(
         mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
-    override fun loadInBackground(): ResultListData<RTListItem> {
+    override suspend fun loadInBackground(): ResultListData<RTListItem> {
         Log.d(TAG, "loadInBackground, query=$query")
 
         val data = ArrayList<RTListItem>()

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/PatternLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/PatternLiveData.kt
@@ -52,7 +52,7 @@ class PatternLiveData(
         val entryPoint = EntryPointAccessors.fromApplication(context.applicationContext, NonAndroidEntryPoint::class.java)
         mDictionary = entryPoint.dictionary()
         mPrefs = entryPoint.prefs()
-        mFavoritesRepository = entryPoint.favorites()
+        mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
     override fun loadInBackground(): ResultListData<RTListItem> {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLiveData.kt
@@ -84,7 +84,7 @@ class RhymerLiveData(
         mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
-    override fun loadInBackground(): ResultListData<RTListItem> {
+    override suspend fun loadInBackground(): ResultListData<RTListItem> {
         Log.d(TAG, "loadInBackground: query=$query, filter=$filter")
         val before = System.currentTimeMillis()
 

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/RhymerLiveData.kt
@@ -81,7 +81,7 @@ class RhymerLiveData(
         mRhymer = entryPoint.rhymer()
         mThesaurus = entryPoint.thesaurus()
         mPrefs = entryPoint.prefs()
-        mFavoritesRepository = entryPoint.favorites()
+        mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
     override fun loadInBackground(): ResultListData<RTListItem> {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLiveData.kt
@@ -80,7 +80,7 @@ class ThesaurusLiveData(
         mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
-    override fun loadInBackground(): ResultListData<RTListItem> {
+    override suspend fun loadInBackground(): ResultListData<RTListItem> {
         Log.d(TAG, "loadInBackground: query=$query, filter=$filter")
 
         val data = ArrayList<RTListItem>()

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/rt/ThesaurusLiveData.kt
@@ -77,7 +77,7 @@ class ThesaurusLiveData(
         mRhymer = entryPoint.rhymer()
         mThesaurus = entryPoint.thesaurus()
         mPrefs = entryPoint.prefs()
-        mFavoritesRepository = entryPoint.favorites()
+        mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
     override fun loadInBackground(): ResultListData<RTListItem> {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/Search.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/Search.kt
@@ -20,8 +20,6 @@
 package ca.rmen.android.poetassistant.main.dictionaries.search
 
 import android.app.Activity
-import android.app.SearchManager
-import android.content.ContentValues
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import androidx.recyclerview.widget.RecyclerView
@@ -35,10 +33,8 @@ import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary
 import ca.rmen.android.poetassistant.widget.DebounceTextWatcher
 import ca.rmen.android.poetassistant.widget.ViewShownScheduler
 import com.google.android.material.search.SearchView
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.util.Locale
 
 /**
@@ -51,11 +47,11 @@ import java.util.Locale
  * This class also configures the SearchView widget, and intercepts searches to add them to
  * the list of suggested words.
  */
-class Search constructor(
+class Search(
     private val searchableActivity: Activity,
     private val viewPager: ViewPager,
     private val dictionary: Dictionary,
-    private val ioDispatcher: CoroutineDispatcher,
+    private val suggestions: Suggestions,
     ) {
     companion object {
         private val TAG = Constants.TAG + Search::class.java.simpleName
@@ -193,10 +189,6 @@ class Search constructor(
      * Adds the given suggestions to the search history, in a background thread.
      */
     suspend fun addSuggestions(suggestion: String) {
-        withContext(ioDispatcher) {
-            val contentValues = ContentValues(1)
-            contentValues.put(SearchManager.QUERY, suggestion)
-            searchableActivity.contentResolver.insert(SuggestionsProvider.CONTENT_URI, contentValues)
-        }
+        suggestions.addSuggestion(suggestion)
     }
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/Search.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/Search.kt
@@ -51,7 +51,7 @@ class Search(
     private val searchableActivity: Activity,
     private val viewPager: ViewPager,
     private val dictionary: Dictionary,
-    private val suggestions: Suggestions,
+    private val suggestionsRepository: SuggestionsRepository,
     ) {
     companion object {
         private val TAG = Constants.TAG + Search::class.java.simpleName
@@ -189,6 +189,6 @@ class Search(
      * Adds the given suggestions to the search history, in a background thread.
      */
     suspend fun addSuggestions(suggestion: String) {
-        suggestions.addSuggestion(suggestion)
+        suggestionsRepository.addSuggestion(suggestion)
     }
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionDao.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionDao.kt
@@ -30,8 +30,8 @@ interface SuggestionDao {
     fun getSuggestions(): Array<Suggestion>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun insertAll(suggestion: Suggestion)
+    suspend fun insertAll(suggestion: Suggestion)
 
     @Query("DELETE FROM SUGGESTION")
-    fun deleteAll()
+    suspend fun deleteAll()
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/Suggestions.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/Suggestions.kt
@@ -19,17 +19,45 @@
 
 package ca.rmen.android.poetassistant.main.dictionaries.search
 
+import android.text.TextUtils
 import androidx.annotation.WorkerThread
+import ca.rmen.android.poetassistant.main.dictionaries.EmbeddedDb
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import java.util.Locale
+
+enum class Source {
+    HISTORY,
+    DICTIONARY,
+}
+
+data class Entry(val source: Source, val word: String)
 
 class Suggestions(
     private val suggestionDao: SuggestionDao,
+    private val embeddedDb: EmbeddedDb,
     private val ioDispatcher: CoroutineDispatcher,
 ) {
 
+    companion object {
+        private const val MAX_PREFIX_MATCHES = 10
+    }
+
     @WorkerThread
-    fun getSuggestions(): List<String> = suggestionDao.getSuggestions().map(Suggestion::getWord)
+    suspend fun getSuggestions(filter: String?): List<Entry> {
+        return withContext(ioDispatcher) {
+            val history = suggestionDao.getSuggestions().map { Entry(Source.HISTORY, it.getWord()) }
+                .asSequence().filter { TextUtils.isEmpty(filter) || it.word.contains(filter!!) }
+                .distinct()
+                .sortedBy { it.word }
+                .toList()
+
+            val similarSoundingWords = if (filter.isNullOrBlank()) emptyList() else
+                findWordsWithPrefix(filter.trim().lowercase(Locale.getDefault())).map {Entry(Source.DICTIONARY, it)}
+
+            history + similarSoundingWords
+        }
+    }
 
     @WorkerThread
     suspend fun addSuggestion(suggestion: String) = withContext(ioDispatcher) {
@@ -40,4 +68,27 @@ class Suggestions(
     suspend fun clear() = withContext(ioDispatcher) {
         suggestionDao.deleteAll()
     }
+
+    /**
+     * @return at most limit words starting with the given prefix
+     */
+    private fun findWordsWithPrefix(prefix: String): Array<String> {
+        val projection = arrayOf("word")
+        val selection = "has_definition=1 AND word LIKE ?"
+        val selectionArgs = arrayOf("$prefix%")
+        val orderBy = "word"
+        embeddedDb.query(true, "word_variants", projection, selection, selectionArgs,
+            orderBy, MAX_PREFIX_MATCHES.toString())?.use { cursor ->
+            if (cursor.count > 0) {
+                val result = Array(cursor.count) { "" }
+                while (cursor.moveToNext()) {
+                    result[cursor.position] = cursor.getString(0)
+                }
+                return result
+            }
+        }
+        return emptyArray()
+    }
+
+
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/Suggestions.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/Suggestions.kt
@@ -20,15 +20,24 @@
 package ca.rmen.android.poetassistant.main.dictionaries.search
 
 import androidx.annotation.WorkerThread
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 
-class Suggestions(private val suggestionDao: SuggestionDao) {
+class Suggestions(
+    private val suggestionDao: SuggestionDao,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
 
     @WorkerThread
     fun getSuggestions(): List<String> = suggestionDao.getSuggestions().map(Suggestion::getWord)
 
     @WorkerThread
-    fun addSuggestion(suggestion: String) = suggestionDao.insertAll(Suggestion(suggestion))
+    suspend fun addSuggestion(suggestion: String) = withContext(ioDispatcher) {
+        suggestionDao.insertAll(Suggestion(suggestion))
+    }
 
     @WorkerThread
-    fun clear() = suggestionDao.deleteAll()
+    suspend fun clear() = withContext(ioDispatcher) {
+        suggestionDao.deleteAll()
+    }
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsCursor.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsCursor.kt
@@ -20,59 +20,42 @@
 package ca.rmen.android.poetassistant.main.dictionaries.search
 
 import android.app.SearchManager
-import android.content.Context
 import android.database.MatrixCursor
 import android.provider.BaseColumns
-import android.text.TextUtils
 import androidx.annotation.DrawableRes
 import ca.rmen.android.poetassistant.R
-import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary
-import java.util.Locale
 
 /**
  * SharedPreferences and db-backed cursor to read suggestions.  Suggestions include
  * words which have been looked up before, as well as similar words in the database.
  */
 class SuggestionsCursor(
-    context: Context,
-    private val dictionary: Dictionary,
     private val suggestions: Suggestions,
     private val filter: String?,
 ) : MatrixCursor(COLUMNS) {
 
     companion object {
-        private val COLUMNS = arrayOf(BaseColumns._ID,
+        private val COLUMNS = arrayOf(
+            BaseColumns._ID,
             SearchManager.SUGGEST_COLUMN_TEXT_1,
             SearchManager.SUGGEST_COLUMN_ICON_1,
-                SearchManager.SUGGEST_COLUMN_INTENT_DATA)
+            SearchManager.SUGGEST_COLUMN_INTENT_DATA
+        )
     }
 
-    init {
-        loadHistory()
-        loadSimilarWords()
-    }
-
-    private fun loadHistory() {
-        // https://code.google.com/p/android/issues/detail?id=226686
-        /*@DrawableRes*/
-        val iconId = R.drawable.ic_search_history
-        val suggestions = suggestions.getSuggestions()
-        suggestions.asSequence().filter { TextUtils.isEmpty(filter) || it.contains(filter!!) }
-            .distinct()
-            .sorted().toList()
-            .forEach { addSuggestion(it, iconId) }
-
-    }
-
-    private fun loadSimilarWords() {
-        if (!TextUtils.isEmpty(filter)) {
-            val similarSoundingWords = dictionary.findWordsWithPrefix(filter!!.trim().lowercase(Locale.getDefault()))
-            // https://code.google.com/p/android/issues/detail?id=226686
-            /*@DrawableRes*/
-            val iconId = R.drawable.ic_action_search
-            similarSoundingWords.forEach { addSuggestion(it, iconId) }
+    suspend fun load() {
+        suggestions.getSuggestions(filter).forEach { entry ->
+            addSuggestion(
+                word = entry.word,
+                iconId = when (entry.source) {
+                    // https://code.google.com/p/android/issues/detail?id=226686
+                    Source.HISTORY -> R.drawable.ic_search_history
+                    Source.DICTIONARY -> R.drawable.ic_action_search
+                }
+            )
         }
     }
+
 
     private fun addSuggestion(word: String, @DrawableRes iconId: Int) {
         addRow(arrayOf<Any>(count, word, iconId, word))

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsCursor.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsCursor.kt
@@ -30,7 +30,7 @@ import ca.rmen.android.poetassistant.R
  * words which have been looked up before, as well as similar words in the database.
  */
 class SuggestionsCursor(
-    private val suggestions: Suggestions,
+    private val suggestionsRepository: SuggestionsRepository,
     private val filter: String?,
 ) : MatrixCursor(COLUMNS) {
 
@@ -44,7 +44,7 @@ class SuggestionsCursor(
     }
 
     suspend fun load() {
-        suggestions.getSuggestions(filter).forEach { entry ->
+        suggestionsRepository.getSuggestions(filter).forEach { entry ->
             addSuggestion(
                 word = entry.word,
                 iconId = when (entry.source) {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsProvider.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsProvider.kt
@@ -68,20 +68,11 @@ class SuggestionsProvider : ContentProvider() {
     }
 
     override fun insert(uri: Uri, values: ContentValues?): Uri? {
-        val suggestion = values?.getAsString(SearchManager.QUERY)
-        if (suggestion != null) {
-            context?.let {
-                getSuggestions(it.applicationContext).addSuggestion(suggestion)
-            }
-        }
-        return null
+        throw UnsupportedOperationException("Use Suggestions Repository")
     }
 
     override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int {
-        context?.let {
-            getSuggestions(it.applicationContext).clear()
-        }
-        return 0
+        throw UnsupportedOperationException("Use Suggestions Repository")
     }
 
     override fun update(p0: Uri, p1: ContentValues?, p2: String?, p3: Array<out String>?): Int {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsProvider.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsProvider.kt
@@ -23,7 +23,6 @@ import android.app.SearchManager
 import android.content.ContentProvider
 import android.content.ContentResolver
 import android.content.ContentValues
-import android.content.Context
 import android.content.UriMatcher
 import android.database.Cursor
 import android.net.Uri
@@ -31,9 +30,6 @@ import android.text.TextUtils
 import ca.rmen.android.poetassistant.BuildConfig
 import ca.rmen.android.poetassistant.di.NonAndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 class SuggestionsProvider : ContentProvider() {
@@ -63,7 +59,7 @@ class SuggestionsProvider : ContentProvider() {
                 NonAndroidEntryPoint::class.java
             )
             val filter = if (!TextUtils.equals(uri.lastPathSegment, SearchManager.SUGGEST_URI_PATH_QUERY)) uri.lastPathSegment else null
-            val cursor = SuggestionsCursor(entryPoint.suggestions(), filter)
+            val cursor = SuggestionsCursor(entryPoint.suggestionsRepository(), filter)
             runBlocking {
                 cursor.load()
             }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsProvider.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsProvider.kt
@@ -30,8 +30,11 @@ import android.net.Uri
 import android.text.TextUtils
 import ca.rmen.android.poetassistant.BuildConfig
 import ca.rmen.android.poetassistant.di.NonAndroidEntryPoint
-import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary
 import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 class SuggestionsProvider : ContentProvider() {
     companion object {
@@ -55,8 +58,16 @@ class SuggestionsProvider : ContentProvider() {
 
     override fun query(uri: Uri, projection: Array<out String>?, sel: String?, selArgs: Array<out String>?, sortOrder: String?): Cursor? {
         return context?.let {
+            val entryPoint = EntryPointAccessors.fromApplication(
+                it.applicationContext,
+                NonAndroidEntryPoint::class.java
+            )
             val filter = if (!TextUtils.equals(uri.lastPathSegment, SearchManager.SUGGEST_URI_PATH_QUERY)) uri.lastPathSegment else null
-            SuggestionsCursor(it, getDictionary(it.applicationContext), getSuggestions(it.applicationContext), filter)
+            val cursor = SuggestionsCursor(entryPoint.suggestions(), filter)
+            runBlocking {
+                cursor.load()
+            }
+            cursor
         }
     }
 
@@ -79,19 +90,6 @@ class SuggestionsProvider : ContentProvider() {
         return 0
     }
 
-    private fun getSuggestions(appContext: Context): Suggestions {
-        val entryPoint = EntryPointAccessors.fromApplication(
-            appContext,
-            NonAndroidEntryPoint::class.java
-        )
-        return entryPoint.suggestions()
-    }
-    private fun getDictionary(appContext: Context): Dictionary{
-        val entryPoint = EntryPointAccessors.fromApplication(
-            appContext,
-            NonAndroidEntryPoint::class.java
-        )
-        return entryPoint.dictionary()
-    }
+
 
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsRepository.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsRepository.kt
@@ -33,7 +33,7 @@ enum class Source {
 
 data class Entry(val source: Source, val word: String)
 
-class Suggestions(
+class SuggestionsRepository(
     private val suggestionDao: SuggestionDao,
     private val embeddedDb: EmbeddedDb,
     private val ioDispatcher: CoroutineDispatcher,

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsRepository.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsRepository.kt
@@ -20,7 +20,6 @@
 package ca.rmen.android.poetassistant.main.dictionaries.search
 
 import android.text.TextUtils
-import androidx.annotation.WorkerThread
 import ca.rmen.android.poetassistant.main.dictionaries.EmbeddedDb
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -43,7 +42,6 @@ class SuggestionsRepository(
         private const val MAX_PREFIX_MATCHES = 10
     }
 
-    @WorkerThread
     suspend fun getSuggestions(filter: String?): List<Entry> {
         return withContext(ioDispatcher) {
             val history = suggestionDao.getSuggestions().map { Entry(Source.HISTORY, it.getWord()) }
@@ -59,12 +57,10 @@ class SuggestionsRepository(
         }
     }
 
-    @WorkerThread
     suspend fun addSuggestion(suggestion: String) = withContext(ioDispatcher) {
         suggestionDao.insertAll(Suggestion(suggestion))
     }
 
-    @WorkerThread
     suspend fun clear() = withContext(ioDispatcher) {
         suggestionDao.deleteAll()
     }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsViewModel.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsViewModel.kt
@@ -37,7 +37,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SuggestionsViewModel @Inject constructor(
     application: Application,
-    private val mSuggestions: Suggestions,
+    private val mSuggestionsRepository: SuggestionsRepository,
     @IODispatcher val ioDispatcher: CoroutineDispatcher,
 ) : AndroidViewModel(application) {
 
@@ -55,7 +55,7 @@ class SuggestionsViewModel @Inject constructor(
 
     fun fetchSuggestions(typedText: String) {
         viewModelScope.launch(ioDispatcher) {
-            _suggestions.value = mSuggestions.getSuggestions(filter = typedText).map { entry ->
+            _suggestions.value = mSuggestionsRepository.getSuggestions(filter = typedText).map { entry ->
                 SearchSuggestion(
                     word = entry.word,
                     iconResource = when (entry.source) {

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsViewModel.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/main/dictionaries/search/SuggestionsViewModel.kt
@@ -20,14 +20,13 @@
 package ca.rmen.android.poetassistant.main.dictionaries.search
 
 import android.app.Application
-import android.app.SearchManager
 import android.util.Log
 import androidx.annotation.DrawableRes
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import ca.rmen.android.poetassistant.Constants
+import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.di.IODispatcher
-import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -37,11 +36,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SuggestionsViewModel @Inject constructor(
-    private val application: Application,
+    application: Application,
     private val mSuggestions: Suggestions,
-    private val dictionary: Dictionary,
     @IODispatcher val ioDispatcher: CoroutineDispatcher,
-    ) : AndroidViewModel(application) {
+) : AndroidViewModel(application) {
 
     data class SearchSuggestion(
         val word: String,
@@ -57,27 +55,16 @@ class SuggestionsViewModel @Inject constructor(
 
     fun fetchSuggestions(typedText: String) {
         viewModelScope.launch(ioDispatcher) {
-
-            val foundSuggestions = mutableListOf<SearchSuggestion>()
-            SuggestionsCursor(
-                application,
-                suggestions = mSuggestions,
-                dictionary = dictionary,
-                filter = typedText
-            ).use { cursor ->
-                val wordColumn = cursor.getColumnIndex(SearchManager.SUGGEST_COLUMN_TEXT_1)
-                val iconColumn = cursor.getColumnIndex(SearchManager.SUGGEST_COLUMN_ICON_1)
-                Log.d(TAG, "${cursor.count} results for $typedText")
-                while (cursor.moveToNext()) {
-                    foundSuggestions.add(
-                        SearchSuggestion(
-                            cursor.getString(wordColumn),
-                            cursor.getInt(iconColumn),
-                        )
-                    )
-                }
+            _suggestions.value = mSuggestions.getSuggestions(filter = typedText).map { entry ->
+                SearchSuggestion(
+                    word = entry.word,
+                    iconResource = when (entry.source) {
+                        Source.HISTORY -> R.drawable.ic_search_history
+                        Source.DICTIONARY -> R.drawable.ic_action_search
+                    }
+                )
             }
-            _suggestions.value = foundSuggestions
+            Log.d(TAG, "${_suggestions.value.size} results for $typedText")
         }
     }
 }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsViewModel.kt
@@ -33,7 +33,7 @@ import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.Tts
 import ca.rmen.android.poetassistant.di.IODispatcher
 import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary
-import ca.rmen.android.poetassistant.main.dictionaries.search.Suggestions
+import ca.rmen.android.poetassistant.main.dictionaries.search.SuggestionsRepository
 import ca.rmen.android.poetassistant.main.reader.PoemFile
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -44,7 +44,7 @@ import javax.inject.Inject
 class SettingsViewModel @Inject constructor(
     application: Application,
     private val mFavoritesRepository: FavoritesRepository,
-    private val suggestions: Suggestions,
+    private val suggestionsRepository: SuggestionsRepository,
     private val mTts: Tts,
     @IODispatcher val ioDispatcher: CoroutineDispatcher,
     private val dictionary: Dictionary,
@@ -107,7 +107,7 @@ class SettingsViewModel @Inject constructor(
 
     fun clearSearchHistory() {
         viewModelScope.launch {
-            suggestions.clear()
+            suggestionsRepository.clear()
             snackbarText.value = getApplication<Application>().getString(R.string.search_history_cleared)
         }
     }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/settings/SettingsViewModel.kt
@@ -33,18 +33,18 @@ import ca.rmen.android.poetassistant.R
 import ca.rmen.android.poetassistant.Tts
 import ca.rmen.android.poetassistant.di.IODispatcher
 import ca.rmen.android.poetassistant.main.dictionaries.dictionary.Dictionary
-import ca.rmen.android.poetassistant.main.dictionaries.search.SuggestionsProvider
+import ca.rmen.android.poetassistant.main.dictionaries.search.Suggestions
 import ca.rmen.android.poetassistant.main.reader.PoemFile
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     application: Application,
     private val mFavoritesRepository: FavoritesRepository,
+    private val suggestions: Suggestions,
     private val mTts: Tts,
     @IODispatcher val ioDispatcher: CoroutineDispatcher,
     private val dictionary: Dictionary,
@@ -107,9 +107,7 @@ class SettingsViewModel @Inject constructor(
 
     fun clearSearchHistory() {
         viewModelScope.launch {
-            withContext(ioDispatcher) {
-                getApplication<Application>().contentResolver.delete(SuggestionsProvider.CONTENT_URI, null, null)
-            }
+            suggestions.clear()
             snackbarText.value = getApplication<Application>().getString(R.string.search_history_cleared)
         }
     }

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/wotd/WotdLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/wotd/WotdLiveData.kt
@@ -55,7 +55,7 @@ class WotdLiveData(
         mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
-    override fun loadInBackground(): ResultListData<WotdListItem> {
+    override suspend fun loadInBackground(): ResultListData<WotdListItem> {
         Log.d(TAG, "loadInBackground")
         val data = ArrayList<WotdListItem>(100)
         val cursor = mDictionary.getRandomWordCursor() ?: return emptyResult()

--- a/app/src/main/kotlin/ca/rmen/android/poetassistant/wotd/WotdLiveData.kt
+++ b/app/src/main/kotlin/ca/rmen/android/poetassistant/wotd/WotdLiveData.kt
@@ -52,7 +52,7 @@ class WotdLiveData(
         val entryPoint = EntryPointAccessors.fromApplication(context.applicationContext, NonAndroidEntryPoint::class.java)
         mDictionary = entryPoint.dictionary()
         mPrefs = entryPoint.prefs()
-        mFavoritesRepository = entryPoint.favorites()
+        mFavoritesRepository = entryPoint.favoritesRepository()
     }
 
     override fun loadInBackground(): ResultListData<WotdListItem> {


### PR DESCRIPTION
* Favorites:
  - Rename favorites to favoritesRepository (missed this in the previous PR)
  - Make FavoritesRepository.getFavorites() suspend
  - Remove redundant @WorkerThread annotations on suspend functions.
* Suggestions:
  - Move code out of SuggestionsCursor into Suggestions "repo".
  - Limit the reference to SuggestionsCursor to SuggestionsProvider, to limit the legacy Android system search api to a minimum of code in the project.
  - Rename Suggestions to SuggestionsRepository.
  - Remove @WorkerThread from suspend functions (it's redundant).